### PR TITLE
Implement option to download Galaxy (instead of cloning it).

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,8 @@
 # Controls which tasks are included, in case you need to perform different
 # options on different hosts or server directories.
 galaxy_manage_clone: yes
+# Download the Galaxy instead cloning, for throw away boxes (e.g. Docker)
+galaxy_manage_download: no
 galaxy_manage_static_setup: yes
 galaxy_manage_mutable_setup: yes
 galaxy_manage_database: yes

--- a/tasks/clone.yml
+++ b/tasks/clone.yml
@@ -21,6 +21,3 @@
   notify:
     - restart galaxy
     - email administrator with changeset id
-
-- name: Create Galaxy virtualenv
-  pip: name=pip virtualenv={{ galaxy_venv_dir }} virtualenv_command="{{ pip_virtualenv_command | default( 'virtualenv' ) }}"

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -1,0 +1,7 @@
+- name: Check for Galaxy download receipt
+  stat: path={{ galaxy_server_dir }}/{{ galaxy_changeset_id }}_receipt
+  register: download_receipt
+
+- name: Replace current version of Galaxy
+  shell: "rm -rf '{{ galaxy_server_dir }}' && mkdir '{{ galaxy_server_dir }}' && wget -q -O - {{ galaxy_repo }}/get/{{ galaxy_changeset_id }}.tar.gz | tar xzf - --strip-components=1 -C {{ galaxy_server_dir }} && touch '{{ galaxy_server_dir }}/{{ galaxy_changeset_id }}_receipt'"
+  when: not download_receipt.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,15 @@
   tags:
     - galaxy_manage_clone
 
+- include: download.yml
+  when: not galaxy_manage_clone and galaxy_manage_download 
+  tags:
+    - galaxy_manage_download
+
+# Only manage virtualenv if obtaining for backward compatibilty
+- include: virtualenv.yml
+  when: galaxy_manage_clone or galaxy_manage_download
+
 - include: static_setup.yml
   when: galaxy_manage_static_setup
 

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -1,0 +1,3 @@
+
+- name: Create Galaxy virtualenv
+  pip: name=pip virtualenv={{ galaxy_venv_dir }} virtualenv_command="{{ pip_virtualenv_command | default( 'virtualenv' ) }}"


### PR DESCRIPTION
Until we have debs this is... a... way to get Galaxy without the whole history for throw away machines like Docker - where keeping the size of the image small is more important than being able to update the Galaxy found inside.