### PR TITLE
Add allow_duplicates to role metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -46,3 +46,4 @@ galaxy_info:
   - system
   - web
 dependencies: []
+allow_duplicates: yes


### PR DESCRIPTION
By default, Ansible will only run a role once, no matter the number of times it occurs as a dependency. This makes this role difficult to use as a building block in creating more complex roles, for instance packaging the example in the readme as a self-contained role (separating mutable config and files from code and the like.

By setting the allow_duplicates option, as detailed in the [Ansible docs](http://docs.ansible.com/playbooks_roles.html#role-dependencies), the composibility of the role is increased.