### PR TITLE
galaxy_shed_tools_dir moved inside Galaxy clone

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,7 +35,7 @@ galaxy_config_dir: "{{ galaxy_server_dir }}"
 galaxy_mutable_config_dir: "{{ galaxy_server_dir }}"
 galaxy_tool_dependency_dir: "{{ galaxy_mutable_data_dir }}/dependencies"
 galaxy_mutable_data_dir: "{{ galaxy_server_dir }}/database"
-galaxy_shed_tools_dir: "{{ galaxy_server_dir }}/../shed_tools"
+galaxy_shed_tools_dir: "{{ galaxy_server_dir }}/shed_tools"
 galaxy_shed_tool_conf_file: "{{ galaxy_mutable_config_dir }}/shed_tool_conf.xml"
 galaxy_requirements_file: "{{ galaxy_server_dir }}/lib/galaxy/dependencies/pinned-requirements.txt"
 


### PR DESCRIPTION
Moving to inside Galaxy clone conforms with line 33. Tested build.

Otherwise `tasks/static_setup.yml` may need to contain a new line 11 with `become: yes`.