### PR TITLE
Updates for download.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,7 @@ galaxy_repo: "{{ galaxy_git_repo | default('https://github.com/galaxyproject/gal
 galaxy_commit_id: "{{ galaxy_changeset_id | default('master') }}"
 
 # Download URL (if used)
-galaxy_download_url: "{{ galaxy_repo | replace('.git', '') }}/archive/{{ galaxy_commit_id | replace('release_', 'v') }}.tar.gz"
+galaxy_download_url: "{{ galaxy_repo | replace('.git', '') }}/archive/{{ galaxy_commit_id }}.tar.gz"
 
 # This will automatically be used by run.sh
 galaxy_venv_dir: "{{ galaxy_server_dir }}/.venv"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,7 @@ galaxy_repo: "{{ galaxy_git_repo | default('https://github.com/galaxyproject/gal
 galaxy_commit_id: "{{ galaxy_changeset_id | default('master') }}"
 
 # Download URL (if used)
-galaxy_download_url: "{{ galaxy_repo }}/get/{{ galaxy_commit_id }}.tar.gz"
+galaxy_download_url: "{{ galaxy_repo | replace('.git', '') }}/archive/{{ galaxy_commit_id | replace('release_', 'v') }}.tar.gz"
 
 # This will automatically be used by run.sh
 galaxy_venv_dir: "{{ galaxy_server_dir }}/.venv"

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -6,6 +6,11 @@
     path: "{{ galaxy_server_dir }}/{{ galaxy_commit_id }}_receipt"
   register: download_receipt
 
+- name: Create Galaxy server directory
+  file:
+    path: "{{ galaxy_server_dir }}"
+    state: directory
+
 - name: Install current version of Galaxy
   unarchive:
     src: "{{ galaxy_download_url }}"

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -1,11 +1,29 @@
+---
+# Manage Galaxy download
+
 - name: Check for Galaxy download receipt
   stat:
     path: "{{ galaxy_server_dir }}/{{ galaxy_commit_id }}_receipt"
   register: download_receipt
 
-- name: Replace current version of Galaxy
-  shell: "rm -rf '{{ galaxy_server_dir }}' && mkdir '{{ galaxy_server_dir }}' && wget -q -O - {{ galaxy_download_url }} | tar xzf - --strip-components=1 -C {{ galaxy_server_dir }} && touch '{{ galaxy_server_dir }}/{{ galaxy_commit_id }}_receipt'"
+- name: Install current version of Galaxy
+  unarchive:
+    src: "{{ galaxy_download_url }}"
+    dest: "{{ galaxy_server_dir }}"
+    extra_opts: --strip-components=1
+    remote_src: yes
+  when: not download_receipt.stat.exists
+
+- name: Create Galaxy download receipt
+  file:
+    path: "{{ galaxy_server_dir }}/{{ galaxy_commit_id }}_receipt"
+    state: touch
   when: not download_receipt.stat.exists
 
 - name: Include virtualenv setup tasks
   include_tasks: virtualenv.yml
+
+- name: Remove orphaned .pyc files and compile bytecode
+  script: makepyc.py {{ galaxy_server_dir }}/lib
+  environment:
+    PATH: "{{ galaxy_venv_dir }}/bin"


### PR DESCRIPTION
Updated `galaxy_download_url` to correct path. e.g.,
  - From: `https://github.com/galaxyproject/galaxy.git/archive/release_18.05.tar.gz`
  - To:      `https://github.com/galaxyproject/galaxy/archive/release_18.05.tar.gz`

Added `makepyc.py` task which comes from `clone.yml`.

Replaced bash which downloads Galaxy and creates a receipt with Ansible modules.
  - In this version `galaxy_server_dir` is not removed. Directory removal was not added because, `clone.yml` does not remove the directory.