### PR TITLE
Edits to sample code/advanced playbook in README (dupl. keys + become: yes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ and start two [job handler mules][deployment-options].
   roles:
     # Install with:
     #   % ansible-galaxy install galaxyproject.postgresql
-    - galaxyproject.postgresql
+    - role: galaxyproject.postgresql
+      become: yes
     # Install with:
     #   % ansible-galaxy install natefoo.postgresql_objects
     - role: natefoo.postgresql_objects

--- a/README.md
+++ b/README.md
@@ -198,8 +198,9 @@ and start two [job handler mules][deployment-options].
           - unix_signal:15 gracefully_kill_them_all
         py-call-osafterfork: true
         enable-threads: true
-        mule: lib/galaxy/main.py
-        mule: lib/galaxy/main.py
+        mules:
+          - mule: lib/galaxy/main.py
+          - mule: lib/galaxy/main.py
         farm: job-handlers:1,2
       galaxy:
         database_connection: "postgresql:///galaxy?host=/var/run/postgresql"


### PR DESCRIPTION
**Edit 1:** add ```become: yes```. Solves permissions issue in the advanced playbook sample code:
`postgresql_conf_dir` is set to `/etc/postgresql/[version]/main` (in
vars/[os-family].yml, which requires privilege escalation.

**Edit 2:** change dictionary duplicate keys (mule) to sequence. 

*Note: this was supposed to be 2 separate PRs. Sorry, github's UI confused me.*