### PR TITLE
Make checking repo dir safe for --check

### DIFF
--- a/tasks/clone.yml
+++ b/tasks/clone.yml
@@ -7,18 +7,18 @@
   register: galaxy_stat_out
 
 - name: Get current Galaxy commit id
-  command: "{{ git_executable | default('git') }} rev-parse HEAD"
-  args:
-      chdir: "{{ galaxy_server_dir }}"
-  register: current_commit_id
-  changed_when: no
+  git:
+    repo: "{{ galaxy_repo }}"
+    dest: "{{ galaxy_server_dir }}"
+    update: no
+  register: current_repo_state
   when: galaxy_stat_out.stat.exists
 
 - name: Report current Galaxy commit id
   debug:
-    msg: "Current version of {{ galaxy_server_dir }} {{ current_commit_id.stdout | default(-1) }} does not match playbook version {{ galaxy_commit_id }}"
-  changed_when: True
-  when: galaxy_stat_out.stat.exists and (current_commit_id.stdout | default(-1) != galaxy_commit_id)
+    msg: "Current version of {{ galaxy_server_dir }} {{ current_repo_state.before }} does not match playbook version {{ galaxy_commit_id }}"
+  changed_when: true
+  when: galaxy_stat_out.stat.exists and (current_repo_state.before != galaxy_commit_id)
 
 - name: Update Galaxy to correct ref (git)
   git:


### PR DESCRIPTION
Using commands meant it wouldn't run during `ansible-playbook --check` which was troublesome for us.