### PR TITLE
Indicate Python version used for creating virtualenv

### DIFF
--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -9,6 +9,7 @@
     name: pip
     virtualenv: "{{ galaxy_venv_dir }}"
     virtualenv_command: "{{ pip_virtualenv_command | default('virtualenv') }}"
+    virtualenv_python: python2.7
   environment:
     VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
 


### PR DESCRIPTION
Add virtualenv_python parameter to pip module in virtualenv.yml.

Rationale: if this parameter is not specified, on some systems Python 3
will be used instead of the required Python 2.

According to Ansible's docs, "When not specified, the Python version
used to run the ansible module is used" (pip module). However,
reagadless what Python executable is used to run Ansible, the pip module
will [call virtualenv](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/packaging/language/pip.py#L487)
*without* the ```--python``` option, thus causing virtualenv to use
["the interpreter that virtualenv was installed with."](https://virtualenv.pypa.io/en/latest/reference/#cmdoption-p),
which could be Python 3 (as was the case with my local system).