### PR TITLE
setting depth param for clone task + minor old PR

### DIFF
--- a/tasks/clone.yml
+++ b/tasks/clone.yml
@@ -27,6 +27,7 @@
     repo: "{{ galaxy_repo }}"
     version: "{{ galaxy_commit_id }}"
     executable: "{{ git_executable | default(omit) }}"
+    depth: "{{ galaxy_repo_clone_depth | default(omit) }}"
   notify:
     - restart galaxy
     - email administrator with commit id

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -9,6 +9,7 @@
     name: pip
     virtualenv: "{{ galaxy_venv_dir }}"
     virtualenv_command: "{{ pip_virtualenv_command | default('virtualenv') }}"
+    virtualenv_python: python2.7
   environment:
     VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
 


### PR DESCRIPTION
Setting the depth param (=1) creates a shallow clone reducing the size of the .git/ directory from 467M to 22M. We need this for constructing a minimal galaxy container image  (see issue #7225).

The parameter is omitted when not defined. 

If this change is OK, I'll add a note about it to the role's README.