### PR TITLE
fix mule in advanced example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,9 @@ and start two [job handler mules][deployment-options].
           - unix_signal:15 gracefully_kill_them_all
         py-call-osafterfork: true
         enable-threads: true
-        mules:
-          - mule: lib/galaxy/main.py
-          - mule: lib/galaxy/main.py
+        mule:
+          - lib/galaxy/main.py
+          - lib/galaxy/main.py
         farm: job-handlers:1,2
       galaxy:
         database_connection: "postgresql:///galaxy?host=/var/run/postgresql"


### PR DESCRIPTION
As referenced by @ic4f in issue #42, the example stating:

```yaml
mules:
  - mule: lib/galaxy/main.py
  - mule: lib/galaxy/main.py
```
Is incorrect and should rather be:
```yaml
mule:
  - lib/galaxy/main.py
  - lib/galaxy/main.py
```

This appears to work correctly.