### PR TITLE
Add optional superuser features for managing users, paths, and privilege separation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,29 +3,18 @@ language: python
 python: "2.7"
 sudo: required
 
-before_install:
-  - export GALAXY_HOME=/home/galaxy
-  - export GALAXY_TRAVIS_USER=galaxy
-  - export GALAXY_UID=1450
-  - export GALAXY_GID=1450
-  - sudo groupadd -r $GALAXY_TRAVIS_USER -g $GALAXY_GID
-  - sudo useradd -u $GALAXY_UID -r -g $GALAXY_TRAVIS_USER -d $GALAXY_HOME -p travis_testing -c "Galaxy user" $GALAXY_TRAVIS_USER
-  - sudo mkdir $GALAXY_HOME
-  - sudo chown -R $GALAXY_TRAVIS_USER:$GALAXY_TRAVIS_USER $GALAXY_HOME
-  - sudo chmod -R 755 $GALAXY_HOME
-
 install:
-  # Install an upgraded pip and virtualenv
+  # Install git
   - sudo apt-get install git
-  - sudo apt-get install python-pip
-  - pip install virtualenv
-  - pip install --upgrade pip
 
-  # Install Ansible.
+  # Install Ansible
   - pip install ansible==2.5
 
-  # Add ansible.cfg to pick up roles path.
+  # Add ansible.cfg to pick up roles path
   - printf '[defaults]\nroles_path = ../' > ansible.cfg
 
 script:
-  - ansible-playbook -i "localhost, " -c local tests/test_playbook.yml
+  # Use sudo since we are using become from an unprivileged user to an unprivileged user, to work around:
+  #   https://docs.ansible.com/ansible/latest/user_guide/become.html#becoming-an-unprivileged-user
+  # On a real system, you would want to use one of the workarounds in the docs (of which this is the third)
+  - sudo $VIRTUAL_ENV/bin/ansible-playbook -i "localhost, " -c local tests/test_playbook.yml

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Options for controlling where certain Galaxy components are placed on the filesy
 **User management and privilege separation**
 
 - `galaxy_separate_privileges` (default: `no`): Enable privilege separation mode.
-- `galaxy_user` (default: `galaxy`): The name of the system user under which Galaxy runs.
+- `galaxy_user` (default: user running ansible): The name of the system user under which Galaxy runs.
 - `galaxy_privsep_user` (default: `root`): The name of the system user that owns the Galaxy code, config files, and
   virtualenv (and dependencies therein).
 - `galaxy_group`: Common group between the Galaxy user and privilege separation user. If set and `galaxy_manage_paths`

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ with the `virtualenv` executable and corresponding `pip_virtualenv_command` vari
 Role Variables
 --------------
 
+Not all variables are listed or explained in detail. For additional information about less commonly used variables, see
+the [defaults file][defaults].
+
+[defaults]: defaults/main.yml
+
 Many variables control where specific files are placed and where Galaxy writes data. In order to simplify configuration,
 you may select a *layout* with the `galaxy_layout` variable. Which layout you choose affects the required variables.
 
@@ -64,7 +69,7 @@ If using `root-dir`:
 
 ### Optional variables ###
 
-Layout control:
+**Layout control**
 
 - `galaxy_layout`: available layouts can be found in the [vars/][vars] subdirectory and possible values include:
   - `root-dir`: Everything is laid out in subdirectories underneath a single root directory.
@@ -83,7 +88,7 @@ Options below that control individual file or subdirectory placement can still o
 [custom]: vars/layout-custom.yml
 [fhs]: http://www.pathname.com/fhs/
 
-New options for Galaxy 18.01 and later:
+**New options for Galaxy 18.01 and later**
 
 - `galaxy_config_style` (default: `ini-paste`): The type of Galaxy configuration file to write, `ini-paste` for the
   traditional PasteDeploy-style INI file, or `yaml` for the YAML format supported by uWSGI.
@@ -103,8 +108,15 @@ New options for Galaxy 18.01 and later:
 
 [uwsgi-863]: https://github.com/unbit/uwsgi/issues/863
 
-Several variables control which functions this role will perform (all default to `yes`):
+**Feature control**
 
+Several variables control which functions this role will perform (all default to `yes` except where noted):
+
+- `galaxy_create_user` (default: `no`): Create the Galaxy user. Running as a dedicated user is a best practice, but most
+  production Galaxy instances submitting jobs to a cluster will manage users in a directory service (e.g.  LDAP). This
+  option is useful for standalone servers. Requires superuser privileges.
+- `galaxy_manage_paths` (default: `no`): Create and manage ownership/permissions of configured Galaxy paths. Requires
+  superuser privileges.
 - `galaxy_manage_clone`: Clone Galaxy from the source repository and maintain it at a specified version (commit), as
   well as set up a [virtualenv][virtualenv] from which it can be run.
 - `galaxy_manage_static_setup`: Manage "static" Galaxy configuration files - ones which are not modifiable by the Galaxy
@@ -113,15 +125,18 @@ Several variables control which functions this role will perform (all default to
   as you install tools from the Galaxy Tool Shed).
 - `galaxy_manage_database`: Upgrade the database schema as necessary, when new schema versions become available.
 - `galaxy_fetch_dependencies`: Fetch Galaxy dependent modules to the Galaxy virtualenv.
-- `galaxy_manage_errordocs`: Install Galaxy-styled 413 and 502 HTTP error documents for nginx
+- `galaxy_manage_errordocs` (default: `no`): Install Galaxy-styled 413 and 502 HTTP error documents for nginx. Requires
+  write privileges for the nginx error document directory.
 
-You can control various things about where you get Galaxy from, what version you use, and where its configuration files
-will be placed:
+**Galaxy code and configuration**
+
+Options for configuring Galaxy and controlling which version is installed.
 
 - `galaxy_config`: The contents of the Galaxy configuration file (`galaxy.ini` by default) are controlled by this
   variable. It is a hash of hashes (or dictionaries) that will be translated in to the configuration
   file. See the Example Playbooks below for usage.
 - `galaxy_config_files`: List of hashes (with `src` and `dest` keys) of files to copy from the control machine.
+- `galaxy_config_templates`: List of hashes (with `src` and `dest` keys) of templates to fill from the control machine.
 - `galaxy_repo` (default: `https://github.com/galaxyproject/galaxy.git`): Upstream Git repository from which Galaxy
   should be cloned.
 - `galaxy_commit_id` (default: `master`): A commit id, tag, branch, or other valid Git reference that Galaxy should be
@@ -131,8 +146,11 @@ will be placed:
       run, and
     - using a real commit id is the only way to explicitly lock Galaxy at a specific version.
 - `galaxy_force_checkout` (default: `no`): If `yes`, any modified files in the Galaxy repository will be discarded.
-- `galaxy_requirements_file` (default: `<galaxy_server_dir>/lib/galaxy/dependencies/pinned-requirements.txt`): The
-  Python `requirements.txt` file that should be used to install Galaxy dependent modules using pip.
+
+**Path configuration**
+
+Options for controlling where certain Galaxy components are placed on the filesystem.
+
 - `galaxy_venv_dir` (default: `<galaxy_server_dir>/.venv`): The role will create a [virtualenv][virtualenv] from which
   Galaxy will run, this controls where the virtualenv will be placed.
 - `galaxy_config_dir` (default: `<galaxy_server_dir>`): Directory that will be used for "static" configuration files.
@@ -141,18 +159,37 @@ will be placed:
 - `galaxy_mutable_data_dir` (default: `<galaxy_server_dir>/database`): Directory that will be used for "mutable" data
   and caches, must be writable by the user running Galaxy.
 - `galaxy_config_file` (default: `<galaxy_config_dir>/galaxy.ini`): Galaxy's primary configuration file.
-- `galaxy_shed_tool_conf_file` (default: `<galaxy_mutable_config_dir>/shed_tool_conf.xml`): Configuration file for tools
-  installed from the Galaxy Tool Shed.
-- `galaxy_config_templates`: List of hashes (with `src` and `dest` keys) of templates to fill from the control machine.
-- `galaxy_admin_email_to`: If set, email this address when Galaxy has been updated. Assumes mail is properly configured
-  on the managed host.
-- `galaxy_admin_email_from`: Address to send the aforementioned email from.
+
+**User management and privilege separation**
+
+- `galaxy_separate_privileges` (default: `no`): Enable privilege separation mode.
+- `galaxy_user` (default: `galaxy`): The name of the system user under which Galaxy runs.
+- `galaxy_privsep_user` (default: `root`): The name of the system user that owns the Galaxy code, config files, and
+  virtualenv (and dependencies therein).
+- `galaxy_group`: Common group between the Galaxy user and privilege separation user. If set and `galaxy_manage_paths`
+  is enabled, directories containing potentially sensitive information such as the Galaxy config file will be created
+  group- but not world-readable. Otherwise, directories are created world-readable.
+
+**Access method control**
+
+The role needs to perform tasks as different users depending on which features you have enabled and how you are
+connecting to the target host. By default, the role will use `become` (i.e. sudo) to perform tasks as the appropriate
+user if deemed necessary. Overriding this behavior is discussed in the [defaults file][defaults].
+
+**Error documents**
+
 - `galaxy_errordocs_dir`: Install Galaxy-styled HTTP 413 and 502 error documents under this directory. The 502 message
   uses nginx server side includes to allow administrators to create a custom message in `~/maint` when Galaxy is down.
   nginx must be configured separately to serve these error documents.
 - `galaxy_errordocs_server_name` (default: Galaxy): used to display the message "`galaxy_errdocs_server_name` cannot be
   reached" on the 502 page.
 - `galaxy_errordocs_prefix` (default: `/error`): Web-side path to the error document root.
+
+**Miscellaneous options**
+
+- `galaxy_admin_email_to`: If set, email this address when Galaxy has been updated. Assumes mail is properly configured
+  on the managed host.
+- `galaxy_admin_email_from`: Address to send the aforementioned email from.
 
 Dependencies
 ------------
@@ -162,7 +199,7 @@ None
 Example Playbook
 ----------------
 
-**Basic:**
+### Basic ###
 
 Install Galaxy on your local system with all the default options:
 
@@ -182,11 +219,16 @@ $ cd /srv/galaxy
 $ sh run.sh
 ```
 
-**Advanced:**
+### Best Practice ###
 
-Install Galaxy with the clone and configs owned by a different user than the user running Galaxy, and backed by
-PostgreSQL, on the hosts in the `galaxyservers` group in your inventory. Additionally, use the 18.01+ style YAML config
-and start two [job handler mules][deployment-options].
+Install Galaxy as per the current production server best practices:
+
+- Galaxy code (clone) is "clean": no configs or mutable data live underneath the clone
+- Galaxy code and static configs are privilege separated: not owned/writeable by the user that runs Galaxy
+- Configuration files are not world-readable
+- PostgreSQL is used as the backing database
+- The 18.01+ style YAML configuration is used
+- Two [job handler mules][deployment-options] are started
 
 [deployment-options]: https://docs.galaxyproject.org/en/master/admin/scaling.html#deployment-options
 
@@ -194,8 +236,15 @@ and start two [job handler mules][deployment-options].
 - hosts: galaxyservers
   vars:
     galaxy_config_style: yaml
-    galaxy_layout: opt
+    galaxy_layout: root-dir
+    galaxy_root: /srv/galaxy
     galaxy_commit_id: release_18.09
+    galaxy_separate_privileges: yes
+    galaxy_create_users: yes
+    galaxy_manage_paths: yes
+    galaxy_user: galaxy
+    galaxy_privsep_user: gxpriv
+    galaxy_group: galaxy
     postgresql_objects_users:
       - name: galaxy
         password: null
@@ -230,34 +279,10 @@ and start two [job handler mules][deployment-options].
       galaxy:
         database_connection: "postgresql:///galaxy?host=/var/run/postgresql"
   pre_tasks:
-    - name: Create Galaxy code owner user
-      user:
-        name: gxcode
-        comment: "Galaxy Code"
-        system: yes
-        home: /opt/galaxy
-        createhome: yes
-      become: yes
-    - name: Create Galaxy runtime user
-      user:
-        name: galaxy
-        comment: "Galaxy Server"
-        system: yes
-        home: /var/opt/galaxy
-        createhome: yes
-      become: yes
     - name: Install Dependencies
       apt:
         name: ['git', 'python-psycopg2', 'python-virtualenv']
       become: yes
-    # Precreating the mutable config directory may be necessary (it's not in our example since we set the user's home
-    # directory to galaxy_mutable_config_dir's parent).
-    #- name: Create mutable configuration file directory
-    #  file:
-    #    path: "{{ galaxy_mutable_config_dir }}"
-    #    owner: galaxy
-    #    state: directory
-    #  become: yes
   roles:
     # Install with:
     #   % ansible-galaxy install galaxyproject.postgresql
@@ -268,16 +293,7 @@ and start two [job handler mules][deployment-options].
     - role: natefoo.postgresql_objects
       become: yes
       become_user: postgres
-    - role: galaxy
-      become: yes
-      become_user: gxcode
-      galaxy_manage_mutable_setup: no
-      galaxy_manage_database: no
-    - role: galaxy
-      become: yes
-      become_user: galaxy
-      galaxy_manage_clone: no
-      galaxy_manage_static_setup: no
+    - role: galaxyproject.galaxy
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,7 +62,7 @@ galaxy_remote_users: {}
 galaxy_separate_privileges: no
 
 # User that Galaxy runs as
-galaxy_user: galaxy
+galaxy_user: "{{ ansible_user_id }}"
 
 # User that owns Galaxy code, configs, and virutalenv, and that runs `pip install` for dependencies
 galaxy_privsep_user: root

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,15 @@
 ---
 # defaults file for galaxyproject.galaxy
 
-# Controls which tasks are included, in case you need to perform different
-# options on different hosts or server directories.
+#
+# Feature control
+#
+
+# Control which tasks are included, in case you need to perform different options on different hosts or server
+# directories.
+galaxy_create_user: no
+galaxy_manage_paths: no
 galaxy_manage_clone: yes
-galaxy_force_checkout: no
-# Download Galaxy instead of cloning, for throw away boxes (e.g. Docker)
 galaxy_manage_download: no
 galaxy_manage_static_setup: yes
 galaxy_manage_mutable_setup: yes
@@ -13,27 +17,109 @@ galaxy_manage_database: yes
 galaxy_fetch_dependencies: yes
 galaxy_manage_errordocs: no
 
-# Directory layout for deployment (legacy is the default)
-#galaxy_layout: legacy
+#
+# Access method control
+#
+
+# The role needs to perform tasks as different users depending on your configuration and how you are connecting to the
+# target host. Keys are the privileges needed and the values are the user to connect as or become:
+#
+#   root: Tasks that require "root" privileges such as creating/chowning directories inside directories owned by root
+#   galaxy: Tasks that run as the Galaxy user
+#   privsep: Tasks that run as the privilege separation user
+#   errdocs: Tasks that install error docs (run as whatever user owns these)
+#
+# You would most commonly connect to the target host either as root or as a user with full sudo privileges, but if not
+# using privilege separation, it is possible to run this role as an unprivileged user with no escalation. In such a
+# case, set `galaxy_become_users` to an empty hash like so:
+#
+#galaxy_become_users: {}
+
+# Attempt to automatically decide whether to use `become` and which users to `become`. To disable, set
+# `galaxy_become_users` to an empty hash.
+__galaxy_privsep_user: "{{ galaxy_privsep_user if galaxy_separate_privileges else galaxy_user }}"
+# this goes through two levels of variables since there's no "else if"
+__galaxy_default_root_become_users:
+  galaxy: "{{ galaxy_user }}"
+  privsep: "{{ __galaxy_privsep_user }}"
+__galaxy_default_nonroot_become_users:
+  root: root
+  galaxy: "{{ galaxy_user }}"
+  privsep: "{{ __galaxy_privsep_user }}"
+__galaxy_default_become_users: "{{ __galaxy_default_root_become_users if ansible_user_uid == 0 else __galaxy_default_nonroot_become_users }}"
+galaxy_become_users: "{{ {} if ansible_user_id == galaxy_user and not galaxy_separate_privileges else __galaxy_default_become_users }}"
+
+# Some sites do not allow the use of passwordless `sudo` and require logging directly in to accounts using `ssh`, this
+# variable works like `galaxy_become_users` and accommodates such scenarios (if using you probably want to set
+# `galaxy_become_users` to an empty hash)
+galaxy_remote_users: {}
+
+#
+# Privilege separation, user and path management
+#
+
+# Privilege separation mode switch
+galaxy_separate_privileges: no
+
+# User that Galaxy runs as
+galaxy_user: galaxy
+
+# User that owns Galaxy code, configs, and virutalenv, and that runs `pip install` for dependencies
+galaxy_privsep_user: root
+
+# No explicit group is created by default, system policy will decide users' groups. However, in order to enable
+# privilege separation without making configs world-readable, the users should share a common group. This group will be
+# created if `galaxy_create_user` is enabled and it does not exist. Ideally this is the primary group of `galaxy_user`,
+# on most Linux systems, just set this to the same value as `galaxy_user` if you want to enable this feature.
+#galaxy_group:
+
+# If `galaxy_create_user` is enabled, the privsep user will also be created, but you can override this behavior
+galaxy_create_privsep_user: "{{ galaxy_create_user if galaxy_privsep_user != 'root' else false }}"
+
+# Directories to create as the Galaxy user if galaxy_manage_paths is enabled
+galaxy_dirs:
+  - "{{ galaxy_mutable_data_dir }}"
+  - "{{ galaxy_mutable_config_dir }}"
+  - "{{ galaxy_cache_dir }}"
+  - "{{ galaxy_shed_tools_dir }}"
+  - "{{ galaxy_tool_dependency_dir }}"
+  - "{{ galaxy_file_path }}"
+  - "{{ galaxy_job_working_directory }}"
+
+# Directories to create as the privilege separated user if galaxy_manage_paths is enabled
+galaxy_privsep_dirs:
+  - "{{ galaxy_venv_dir }}"
+  - "{{ galaxy_server_dir }}"
+  - "{{ galaxy_config_dir }}"
+
+#
+# Version control
+#
 
 # Where to clone Galaxy from. Backwards compatibility with galaxy_git_repo
 galaxy_repo: "{{ galaxy_git_repo | default('https://github.com/galaxyproject/galaxy.git') }}"
 
-# This can be a tag (as shown here) but doing so will cause the revision check
-# task to always report "changed". Backwards compatibility with
-# galaxy_changeset_id.
+# Automatically delete things in the repo that do not belong there
+galaxy_force_checkout: no
+
+# This can be a tag (as shown here) but doing so will cause the revision check task to always report "changed".
+# Backwards compatibility with galaxy_changeset_id.
 galaxy_commit_id: "{{ galaxy_changeset_id | default('master') }}"
 
 # Download URL (if used)
 galaxy_download_url: "{{ galaxy_repo | replace('.git', '') }}/archive/{{ galaxy_commit_id }}.tar.gz"
 
-# TODO: Implement something like this for starter/restarter
-#galaxy_server_type: paste_singleprocess
+#
+# Path and Galaxy configuration
+#
+
+# Directory layout for deployment (legacy is the default)
+#galaxy_layout: legacy
 
 # The shed tool conf path is needed separate from the value of tool_conf for instantiation
 galaxy_shed_tool_conf_file: "{{ galaxy_mutable_config_dir }}/shed_tool_conf.xml"
 
-# Avoid hardcoding paths that could change in tasks
+# The Python `requirements.txt` file that should be used to install Galaxy dependent modules using pip
 galaxy_requirements_file: "{{ galaxy_server_dir }}/lib/galaxy/dependencies/pinned-requirements.txt"
 
 # Galaxy config file can either be 'ini-paste' (old style) or 'yaml'
@@ -43,8 +129,8 @@ galaxy_config_file_template: "{{ galaxy_config_file_basename }}.j2"
 galaxy_config_file: "{{ galaxy_config_dir }}/{{ galaxy_config_file_basename }}"
 galaxy_app_config_section: "{{ 'galaxy' if galaxy_config_style in ('yaml', 'yml') else 'app:main' }}"
 
-# The default Galaxy configuration, ensures that Galaxy can find all of the
-# configs if galaxy_config_dir != galaxy_server_dir
+# The default Galaxy configuration, ensures that Galaxy can find all of the configs if galaxy_config_dir !=
+# galaxy_server_dir
 galaxy_paste_app_factory: "galaxy.web.buildapp:app_factory"
 galaxy_app_config_default:
   # Defaults for sample configs that require a value to be set
@@ -87,8 +173,7 @@ galaxy_app_config_default:
 galaxy_config_default: "{{ {} | combine({galaxy_app_config_section: galaxy_app_config_default}) }}"
 galaxy_config_merged: "{{ galaxy_config_default | combine(galaxy_config | default({}), recursive=True) }}"
 
-# Automatically instantiate mutable config files if they don't exist (dest will
-# not be overwritten if it exists)
+# Automatically instantiate mutable config files if they don't exist (dest will not be overwritten if it exists)
 galaxy_mutable_configs:
   - src: "{{ galaxy_server_dir }}/config/shed_tool_conf.xml.sample"
     dest: "{{ galaxy_shed_tool_conf_file }}"
@@ -104,13 +189,12 @@ galaxy_config_instance_resource_url: "{{ galaxy_config_merged[galaxy_app_config_
 galaxy_errordocs_server_name: Galaxy
 galaxy_errordocs_prefix: /error
 
-
-# These are lists of hashes in the same format as galaxy_mutable_configs that
-# can be used to cause extra files and templates to be installed on the managed
-# host.
+# These are lists of hashes in the same format as galaxy_mutable_configs that can be used to cause extra files and
+# templates to be installed on the managed host.
 galaxy_config_files: []
 galaxy_config_templates: []
 
+# Default uWSGI configuration
 galaxy_uwsgi_yaml_parser: internal
 galaxy_uwsgi_config_default:
   http: 127.0.0.1:8080
@@ -132,3 +216,6 @@ galaxy_uwsgi_config_default:
     - unix_signal:15 gracefully_kill_them_all
   py-call-osafterfork: true
   enable-threads: true
+
+# TODO: Implement something like this for starter/restarter
+#galaxy_server_type: paste_singleprocess

--- a/tasks/clone.yml
+++ b/tasks/clone.yml
@@ -1,40 +1,47 @@
 ---
 # Manage Galaxy clone
 
-- name: Check for Galaxy
-  stat:
-    path: "{{ galaxy_server_dir }}/lib/galaxy"
-  register: galaxy_stat_out
+- name: Clone Galaxy
+  block:
 
-- name: Get current Galaxy commit id
-  command: "{{ git_executable | default('git') }} rev-parse HEAD"
-  args:
-      chdir: "{{ galaxy_server_dir }}"
-  register: current_commit_id
-  changed_when: no
-  when: galaxy_stat_out.stat.exists
+    - name: Check for Galaxy
+      stat:
+        path: "{{ galaxy_server_dir }}/lib/galaxy"
+      register: galaxy_stat_out
 
-- name: Report current Galaxy commit id
-  debug:
-    msg: "Current version of {{ galaxy_server_dir }} {{ current_commit_id.stdout | default(-1) }} does not match playbook version {{ galaxy_commit_id }}"
-  changed_when: True
-  when: galaxy_stat_out.stat.exists and (current_commit_id.stdout | default(-1) != galaxy_commit_id)
+    - name: Get current Galaxy commit id
+      command: "{{ git_executable | default('git') }} rev-parse HEAD"
+      args:
+          chdir: "{{ galaxy_server_dir }}"
+      register: current_commit_id
+      changed_when: no
+      when: galaxy_stat_out.stat.exists
 
-- name: Update Galaxy to correct ref (git)
-  git:
-    dest: "{{ galaxy_server_dir }}"
-    force: "{{ galaxy_force_checkout }}"
-    repo: "{{ galaxy_repo }}"
-    version: "{{ galaxy_commit_id }}"
-    executable: "{{ git_executable | default(omit) }}"
-  notify:
-    - restart galaxy
-    - email administrator with commit id
+    - name: Report current Galaxy commit id
+      debug:
+        msg: "Current version of {{ galaxy_server_dir }} {{ current_commit_id.stdout | default(-1) }} does not match playbook version {{ galaxy_commit_id }}"
+      changed_when: True
+      when: galaxy_stat_out.stat.exists and (current_commit_id.stdout | default(-1) != galaxy_commit_id)
 
-- name: Include virtualenv setup tasks
-  include_tasks: virtualenv.yml
+    - name: Update Galaxy to correct ref (git)
+      git:
+        dest: "{{ galaxy_server_dir }}"
+        force: "{{ galaxy_force_checkout }}"
+        repo: "{{ galaxy_repo }}"
+        version: "{{ galaxy_commit_id }}"
+        executable: "{{ git_executable | default(omit) }}"
+      notify:
+        - restart galaxy
+        - email administrator with commit id
 
-- name: Remove orphaned .pyc files and compile bytecode
-  script: "makepyc.py {{ galaxy_server_dir }}/lib"
-  environment:
-    PATH: "{{ galaxy_venv_dir }}/bin"
+    - name: Include virtualenv setup tasks
+      include_tasks: virtualenv.yml
+
+    - name: Remove orphaned .pyc files and compile bytecode
+      script: "makepyc.py {{ galaxy_server_dir }}/lib"
+      environment:
+        PATH: "{{ galaxy_venv_dir }}/bin"
+
+  remote_user: "{{ galaxy_remote_users.privsep | default(omit) }}"
+  become: "{{ galaxy_become_users.privsep is not undefined }}"
+  become_user: "{{ galaxy_become_users.privsep | default(omit) }}"

--- a/tasks/clone.yml
+++ b/tasks/clone.yml
@@ -35,7 +35,7 @@
         - email administrator with commit id
 
     - name: Include virtualenv setup tasks
-      include_tasks: virtualenv.yml
+      import_tasks: virtualenv.yml
 
     - name: Remove orphaned .pyc files and compile bytecode
       script: "makepyc.py {{ galaxy_server_dir }}/lib"

--- a/tasks/database.yml
+++ b/tasks/database.yml
@@ -1,35 +1,42 @@
 ---
 # Manage Galaxy Database
 
-- name: Get current Galaxy DB version
-  command: "{{ galaxy_venv_dir }}/bin/python {{ galaxy_server_dir }}/scripts/manage_db.py -c {{ galaxy_config_file }} db_version"
-  args:
-    chdir: "{{ galaxy_server_dir }}"
-  register: current_db_version
-  changed_when: no
-  failed_when: current_db_version.rc != 0 and 'migrate.exceptions.DatabaseNotControlledError' not in current_db_version.stderr
+- name: Manage Galaxy database
+  block:
 
-- name: Get maximum Galaxy DB version
-  command: "{{ galaxy_venv_dir }}/bin/python {{ galaxy_server_dir }}/scripts/manage_db.py -c {{ galaxy_config_file }} version"
-  args:
-    chdir: "{{ galaxy_server_dir }}"
-  register: max_db_version
-  changed_when: no
+    - name: Get current Galaxy DB version
+      command: "{{ galaxy_venv_dir }}/bin/python {{ galaxy_server_dir }}/scripts/manage_db.py -c {{ galaxy_config_file }} db_version"
+      args:
+        chdir: "{{ galaxy_server_dir }}"
+      register: current_db_version
+      changed_when: no
+      failed_when: current_db_version.rc != 0 and 'migrate.exceptions.DatabaseNotControlledError' not in current_db_version.stderr
 
-- name: Create Galaxy DB
-  command: "{{ galaxy_venv_dir }}/bin/python {{ galaxy_server_dir }}/scripts/create_db.py -c {{ galaxy_config_file }}"
-  args:
-    chdir: "{{ galaxy_server_dir }}"
-  when: "'migrate.exceptions.DatabaseNotControlledError' in current_db_version.stderr"
+    - name: Get maximum Galaxy DB version
+      command: "{{ galaxy_venv_dir }}/bin/python {{ galaxy_server_dir }}/scripts/manage_db.py -c {{ galaxy_config_file }} version"
+      args:
+        chdir: "{{ galaxy_server_dir }}"
+      register: max_db_version
+      changed_when: no
 
-- name: Report current and max Galaxy database
-  debug:
-    msg: "Current database version is {{ current_db_version.stdout }} and the maxiumum version is {{ max_db_version.stdout }}."
-  changed_when: True
-  when: current_db_version.stdout != max_db_version.stdout and 'migrate.exceptions.DatabaseNotControlledError' not in current_db_version.stderr
+    - name: Create Galaxy DB
+      command: "{{ galaxy_venv_dir }}/bin/python {{ galaxy_server_dir }}/scripts/create_db.py -c {{ galaxy_config_file }}"
+      args:
+        chdir: "{{ galaxy_server_dir }}"
+      when: "'migrate.exceptions.DatabaseNotControlledError' in current_db_version.stderr"
 
-- name: Upgrade Galaxy DB
-  command: "{{ galaxy_venv_dir }}/bin/python {{ galaxy_server_dir }}/scripts/manage_db.py -c {{ galaxy_config_file }} upgrade"
-  args:
-    chdir: "{{ galaxy_server_dir }}"
-  when: current_db_version.stdout != max_db_version.stdout and 'migrate.exceptions.DatabaseNotControlledError' not in current_db_version.stderr
+    - name: Report current and max Galaxy database
+      debug:
+        msg: "Current database version is {{ current_db_version.stdout }} and the maxiumum version is {{ max_db_version.stdout }}."
+      changed_when: True
+      when: current_db_version.stdout != max_db_version.stdout and 'migrate.exceptions.DatabaseNotControlledError' not in current_db_version.stderr
+
+    - name: Upgrade Galaxy DB
+      command: "{{ galaxy_venv_dir }}/bin/python {{ galaxy_server_dir }}/scripts/manage_db.py -c {{ galaxy_config_file }} upgrade"
+      args:
+        chdir: "{{ galaxy_server_dir }}"
+      when: current_db_version.stdout != max_db_version.stdout and 'migrate.exceptions.DatabaseNotControlledError' not in current_db_version.stderr
+
+  remote_user: "{{ galaxy_remote_users.galaxy | default(omit) }}"
+  become: "{{ galaxy_become_users.galaxy is not undefined }}"
+  become_user: "{{ galaxy_become_users.galaxy | default(omit) }}"

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -1,33 +1,39 @@
 ---
 # Manage Galaxy framework dependencies
 
-- name: Include virtualenv setup tasks
-  include_tasks: virtualenv.yml
+- name: Manage dependencies
+  block:
 
-# virtualenv_command is still required if `virtualenv` isn't on $PATH, even if the venv already exists.
-- name: Install Galaxy base dependencies
-  pip:
-    requirements: "{{ galaxy_requirements_file }}"
-    extra_args: "--index-url https://wheels.galaxyproject.org/simple/ --extra-index-url https://pypi.python.org/simple"
-    virtualenv: "{{ galaxy_venv_dir }}"
-    virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
-  environment:
-    PYTHONPATH: null
-    VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+    - name: Include virtualenv setup tasks
+      include_tasks: virtualenv.yml
 
-- name: Collect Galaxy conditional dependency requirement strings
-  command: "{{ galaxy_venv_dir }}/bin/python -c \"import galaxy.dependencies; print('\\n'.join(galaxy.dependencies.optional('{{ galaxy_config_file }}')))\""
-  environment:
-    PYTHONPATH: "{{ galaxy_server_dir }}/lib"
-  register: conditional_dependencies
+    # virtualenv_command is still required if `virtualenv` isn't on $PATH, even if the venv already exists.
+    - name: Install Galaxy base dependencies
+      pip:
+        requirements: "{{ galaxy_requirements_file }}"
+        extra_args: "--index-url https://wheels.galaxyproject.org/simple/ --extra-index-url https://pypi.python.org/simple"
+        virtualenv: "{{ galaxy_venv_dir }}"
+        virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
+      environment:
+        PYTHONPATH: null
+        VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
 
-- name: Install Galaxy conditional dependencies
-  pip: 
-    name: "{{ item }}"
-    extra_args: "--index-url https://wheels.galaxyproject.org/simple/ --extra-index-url https://pypi.python.org/simple"
-    virtualenv: "{{ galaxy_venv_dir }}"
-    virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
-  with_items: "{{ conditional_dependencies.stdout_lines }}"
-  environment:
-    PYTHONPATH: null
-    VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+    - name: Collect Galaxy conditional dependency requirement strings
+      command: "{{ galaxy_venv_dir }}/bin/python -c \"import galaxy.dependencies; print('\\n'.join(galaxy.dependencies.optional('{{ galaxy_config_file }}')))\""
+      environment:
+        PYTHONPATH: "{{ galaxy_server_dir }}/lib"
+      register: conditional_dependencies
+
+    - name: Install Galaxy conditional dependencies
+      pip:
+        name: "{{ conditional_dependencies.stdout_lines }}"
+        extra_args: "--index-url https://wheels.galaxyproject.org/simple/ --extra-index-url https://pypi.python.org/simple"
+        virtualenv: "{{ galaxy_venv_dir }}"
+        virtualenv_command: "{{ pip_virtualenv_command | default( 'virtualenv' ) }}"
+      environment:
+        PYTHONPATH: null
+        VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+
+  remote_user: "{{ galaxy_remote_users.privsep | default(omit) }}"
+  become: "{{ galaxy_become_users.privsep is not undefined }}"
+  become_user: "{{ galaxy_become_users.privsep | default(omit) }}"

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -5,7 +5,7 @@
   block:
 
     - name: Include virtualenv setup tasks
-      include_tasks: virtualenv.yml
+      import_tasks: virtualenv.yml
 
     # virtualenv_command is still required if `virtualenv` isn't on $PATH, even if the venv already exists.
     - name: Install Galaxy base dependencies
@@ -33,6 +33,7 @@
       environment:
         PYTHONPATH: null
         VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+      when: conditional_dependencies.stdout_lines | length > 0
 
   remote_user: "{{ galaxy_remote_users.privsep | default(omit) }}"
   become: "{{ galaxy_become_users.privsep is not undefined }}"

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -29,7 +29,7 @@
       when: not download_receipt.stat.exists
 
     - name: Include virtualenv setup tasks
-      include_tasks: virtualenv.yml
+      import_tasks: virtualenv.yml
 
     - name: Remove orphaned .pyc files and compile bytecode
       script: makepyc.py {{ galaxy_server_dir }}/lib

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -1,34 +1,41 @@
 ---
 # Manage Galaxy download
 
-- name: Check for Galaxy download receipt
-  stat:
-    path: "{{ galaxy_server_dir }}/{{ galaxy_commit_id }}_receipt"
-  register: download_receipt
+- name: Download Galaxy
+  block:
 
-- name: Create Galaxy server directory
-  file:
-    path: "{{ galaxy_server_dir }}"
-    state: directory
+    - name: Check for Galaxy download receipt
+      stat:
+        path: "{{ galaxy_server_dir }}/{{ galaxy_commit_id }}_receipt"
+      register: download_receipt
 
-- name: Install current version of Galaxy
-  unarchive:
-    src: "{{ galaxy_download_url }}"
-    dest: "{{ galaxy_server_dir }}"
-    extra_opts: --strip-components=1
-    remote_src: yes
-  when: not download_receipt.stat.exists
+    - name: Create Galaxy server directory
+      file:
+        path: "{{ galaxy_server_dir }}"
+        state: directory
 
-- name: Create Galaxy download receipt
-  file:
-    path: "{{ galaxy_server_dir }}/{{ galaxy_commit_id }}_receipt"
-    state: touch
-  when: not download_receipt.stat.exists
+    - name: Install current version of Galaxy
+      unarchive:
+        src: "{{ galaxy_download_url }}"
+        dest: "{{ galaxy_server_dir }}"
+        extra_opts: --strip-components=1
+        remote_src: yes
+      when: not download_receipt.stat.exists
 
-- name: Include virtualenv setup tasks
-  include_tasks: virtualenv.yml
+    - name: Create Galaxy download receipt
+      file:
+        path: "{{ galaxy_server_dir }}/{{ galaxy_commit_id }}_receipt"
+        state: touch
+      when: not download_receipt.stat.exists
 
-- name: Remove orphaned .pyc files and compile bytecode
-  script: makepyc.py {{ galaxy_server_dir }}/lib
-  environment:
-    PATH: "{{ galaxy_venv_dir }}/bin"
+    - name: Include virtualenv setup tasks
+      include_tasks: virtualenv.yml
+
+    - name: Remove orphaned .pyc files and compile bytecode
+      script: makepyc.py {{ galaxy_server_dir }}/lib
+      environment:
+        PATH: "{{ galaxy_venv_dir }}/bin"
+
+  remote_user: "{{ galaxy_remote_users.privsep | default(omit) }}"
+  become: "{{ galaxy_become_users.privsep is not undefined }}"
+  become_user: "{{ galaxy_become_users.privsep | default(omit) }}"

--- a/tasks/errordocs.yml
+++ b/tasks/errordocs.yml
@@ -1,36 +1,43 @@
 ---
 
-- name: Create error document directories
-  file:
-    path: "{{ galaxy_errordocs_dest }}/{{ item }}"
-    mode: "0755"
-    state: "directory"
-  with_items:
-    - 413
-    - 502
+- name: Manage error documents
+  block:
 
-- name: Install error documents static files
-  copy:
-    src: "errordocs/{{ item }}"
-    dest: "{{ galaxy_errordocs_dest }}/{{ item }}"
-    mode: "0644"
-  with_items:
-    - content_bg.png
-    - error_message_icon.png
-    - masthead_bg.png
+    - name: Create error document directories
+      file:
+        path: "{{ galaxy_errordocs_dest }}/{{ item }}"
+        mode: "0755"
+        state: "directory"
+      with_items:
+        - 413
+        - 502
 
-- name: Install error document templates
-  template:
-    src: "errordocs/{{ item }}.j2"
-    dest: "{{ galaxy_errordocs_dest }}/{{ item }}"
-    mode: "0644"
-  with_items:
-    - 413/index.html
-    - 502/index.shtml
+    - name: Install error documents static files
+      copy:
+        src: "errordocs/{{ item }}"
+        dest: "{{ galaxy_errordocs_dest }}/{{ item }}"
+        mode: "0644"
+      with_items:
+        - content_bg.png
+        - error_message_icon.png
+        - masthead_bg.png
 
-- name: Create maintenance message link
-  file:
-    path: "{{ galaxy_errordocs_dest }}/502/maint"
-    src: "{{ galaxy_errordocs_maint_file | default('~/maint') }}"
-    state: link
-    force: yes
+    - name: Install error document templates
+      template:
+        src: "errordocs/{{ item }}.j2"
+        dest: "{{ galaxy_errordocs_dest }}/{{ item }}"
+        mode: "0644"
+      with_items:
+        - 413/index.html
+        - 502/index.shtml
+
+    - name: Create maintenance message link
+      file:
+        path: "{{ galaxy_errordocs_dest }}/502/maint"
+        src: "{{ galaxy_errordocs_maint_file | default('~/maint') }}"
+        state: link
+        force: yes
+
+  remote_user: "{{ galaxy_remote_users.errdocs | default(omit) }}"
+  become: "{{ galaxy_become_users.errdocs is not undefined }}"
+  become_user: "{{ galaxy_become_users.errdocs | default(omit) }}"

--- a/tasks/layout.yml
+++ b/tasks/layout.yml
@@ -12,8 +12,8 @@
     - galaxy_venv_dir
     - galaxy_server_dir
     - galaxy_config_dir
-    - galaxy_mutable_config_dir
     - galaxy_mutable_data_dir
+    - galaxy_mutable_config_dir
     - galaxy_shed_tools_dir
     - galaxy_cache_dir
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,18 @@
   import_tasks: layout.yml
   tags: always
 
+- name: Include user creation tasks
+  include_tasks: user.yml
+  when: galaxy_create_user or galaxy_create_privsep_user
+  tags:
+    - galaxy_create_user
+
+- name: Include path management tasks
+  include_tasks: paths.yml
+  when: galaxy_manage_paths
+  tags:
+    - galaxy_manage_paths
+
 - name: Include clone tasks
   include_tasks: clone.yml
   when: galaxy_manage_clone
@@ -30,15 +42,23 @@
 - name: Include dependency setup tasks
   include_tasks: dependencies.yml
   when: galaxy_fetch_dependencies
+  tags:
+    - galaxy_fetch_dependencies
 
 - name: Include mutable config setup tasks
   include_tasks: mutable_setup.yml
   when: galaxy_manage_mutable_setup
+  tags:
+    - galaxy_manage_mutable_setup
 
 - name: Include database management tasks
   include_tasks: database.yml
   when: galaxy_manage_database
+  tags:
+    - galaxy_manage_database
 
 - name: Include error document setup tasks
   include_tasks: errordocs.yml
   when: galaxy_manage_errordocs
+  tags:
+    - galaxy_manage_errordocs

--- a/tasks/mutable_setup.yml
+++ b/tasks/mutable_setup.yml
@@ -1,16 +1,23 @@
 ---
 # Instantiate mutable config files
 
-- name: Create mutable configuration file directories
-  file:
-    path: "{{ item }}"
-    state: directory
-  with_items:
-    - "{{ galaxy_mutable_config_dir }}"
-    - "{{ galaxy_tool_dependency_dir }}"
+- name: Mutable config setup
+  block:
 
-- name: Instantiate mutable configuration files
-  command: cp {{ item.src }} {{ item.dest }}
-  args:
-    creates: "{{ item.dest }}"
-  with_items: "{{ galaxy_mutable_configs }}"
+    - name: Create mutable configuration file directories
+      file:
+        path: "{{ item }}"
+        state: directory
+      with_items:
+        - "{{ galaxy_mutable_config_dir }}"
+        - "{{ galaxy_tool_dependency_dir }}"
+
+    - name: Instantiate mutable configuration files
+      command: cp {{ item.src }} {{ item.dest }}
+      args:
+        creates: "{{ item.dest }}"
+      with_items: "{{ galaxy_mutable_configs }}"
+
+  remote_user: "{{ galaxy_remote_users.galaxy | default(omit) }}"
+  become: "{{ galaxy_become_users.galaxy is not undefined }}"
+  become_user: "{{ galaxy_become_users.galaxy | default(omit) }}"

--- a/tasks/paths.yml
+++ b/tasks/paths.yml
@@ -1,0 +1,66 @@
+---
+
+- name: Manage Paths
+  block:
+
+    - name: Get group IDs for Galaxy users
+      getent:
+        database: passwd
+        key: "{{ item }}"
+      with_items:
+        - "{{ galaxy_user }}"
+        - "{{ __galaxy_privsep_user }}"
+      when: galaxy_group is not defined
+      register: __galaxy_passwd_result
+
+    - name: Get group names for Galaxy users
+      getent:
+        database: group
+        key: "{{ item.ansible_facts.getent_passwd[item.invocation.module_args.key][2] }}"
+      with_items: "{{ __galaxy_passwd_result.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+      when: galaxy_group is not defined
+      register: __galaxy_group_result
+
+    - name: Set Galaxy user facts
+      set_fact:
+        __galaxy_user_group: "{{ galaxy_group if galaxy_group is defined else __galaxy_group_result.results[0].ansible_facts.getent_group.keys() | first }}"
+        __galaxy_privsep_user_group: "{{ galaxy_group if galaxy_group is defined else __galaxy_group_result.results[1].ansible_facts.getent_group.keys() | first }}"
+
+    - name: Determine whether to restrict to group permissions
+      set_fact:
+        __galaxy_dir_perms: "{{ '0750' if __galaxy_user_group == __galaxy_privsep_user_group else '0755' }}"
+
+    # try to become root. if you need something fancier, don't use the role and write your own
+    - name: Create galaxy_root
+      file:
+        path: "{{ galaxy_root }}"
+        state: directory
+        owner: "{{ __galaxy_privsep_user }}"
+        group: "{{ __galaxy_privsep_user_group }}"
+        mode: "{{ __galaxy_dir_perms }}"
+      when: galaxy_root is defined
+
+    - name: Create additional privilege separated directories
+      file:
+        path: "{{ item }}"
+        state: directory
+        owner: "{{ __galaxy_privsep_user }}"
+        group: "{{ __galaxy_privsep_user_group }}"
+        mode: "{{ __galaxy_dir_perms }}"
+      with_items: "{{ galaxy_privsep_dirs }}"
+
+    - name: Create additional directories
+      file:
+        path: "{{ item }}"
+        state: directory
+        owner: "{{ galaxy_user }}"
+        group: "{{ __galaxy_user_group }}"
+        mode: "{{ __galaxy_dir_perms }}"
+      with_items: "{{ galaxy_dirs }}"
+
+  # TODO: for root squashing it might be useful for this to be separate from other root tasks
+  remote_user: "{{ galaxy_remote_users.root | default(omit) }}"
+  become: "{{ galaxy_become_users.root is not undefined }}"
+  become_user: "{{ galaxy_become_users.root | default(omit) }}"

--- a/tasks/static_setup.yml
+++ b/tasks/static_setup.yml
@@ -1,32 +1,39 @@
 ---
 # Manage static Galaxy configuration files
 
-- name: Create Galaxy config and shed tools directory
-  file:
-    path: "{{ item }}"
-    state: directory
-  with_items:
-    - "{{ galaxy_config_dir }}"
-    - "{{ galaxy_shed_tools_dir }}"
+- name: Static config setup
+  block:
 
-- name: Install additional Galaxy config files (static)
-  copy:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
-    backup: yes
-  with_items: "{{ galaxy_config_files }}"
+    - name: Create Galaxy config and shed tools directory
+      file:
+        path: "{{ item }}"
+        state: directory
+      with_items:
+        - "{{ galaxy_config_dir }}"
+        - "{{ galaxy_shed_tools_dir }}"
 
-- name: Install additional Galaxy config files (template)
-  template:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
-    backup: yes
-  with_items: "{{ galaxy_config_templates }}"
+    - name: Install additional Galaxy config files (static)
+      copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        backup: yes
+      with_items: "{{ galaxy_config_files }}"
 
-- name: Create Galaxy configuration file
-  template:
-    src: "{{ galaxy_config_file_template }}"
-    dest: "{{ galaxy_config_file }}"
-    backup: yes
-  notify:
-    - restart galaxy
+    - name: Install additional Galaxy config files (template)
+      template:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        backup: yes
+      with_items: "{{ galaxy_config_templates }}"
+
+    - name: Create Galaxy configuration file
+      template:
+        src: "{{ galaxy_config_file_template }}"
+        dest: "{{ galaxy_config_file }}"
+        backup: yes
+      notify:
+        - restart galaxy
+
+  remote_user: "{{ galaxy_remote_users.privsep | default(omit) }}"
+  become: "{{ galaxy_become_users.privsep is not undefined }}"
+  become_user: "{{ galaxy_become_users.privsep | default(omit) }}"

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -1,0 +1,42 @@
+---
+
+- name: Create users
+  block:
+
+    - name: Create Galaxy group
+      group:
+        name: "{{ galaxy_group.name | default(galaxy_group) }}"
+        gid: "{{ galaxy_group.gid | default(omit) }}"
+        system: "{{ galaxy_group.system | default(galaxy_user.system) | default('true') }}"
+        local: "{{ galaxy_group.local | default(galaxy_user.local) | default(omit) }}"
+      when: galaxy_group is defined
+
+    - name: Create Galaxy user
+      user:
+        name: "{{ galaxy_user.name | default(galaxy_user) }}"
+        uid: "{{ galaxy_user.uid | default(omit) }}"
+        group: "{{ (galaxy_group | default({})).name | default(galaxy_group) | default(omit) }}"
+        comment: "{{ galaxy_user.comment | default('Galaxy server') }}"
+        create_home: "{{ galaxy_user.create_home | default('true') }}"
+        home: "{{ galaxy_user.home | default(omit) }}"
+        shell: "{{ galaxy_user.shell | default(omit) }}"
+        system: "{{ galaxy_user.system | default('true') }}"
+        local: "{{ galaxy_user.local | default(omit) }}"
+      when: galaxy_create_user
+
+    - name: Create Galaxy privilege separation user
+      user:
+        name: "{{ galaxy_privsep_user.name | default(galaxy_privsep_user) }}"
+        uid: "{{ galaxy_privsep_user.uid | default(omit) }}"
+        group: "{{ (galaxy_group | default({})).name | default(galaxy_group) | default(omit) }}"
+        comment: "{{ galaxy_privsep_user.comment | default('Galaxy server privilege separation') }}"
+        create_home: "{{ galaxy_privsep_user.create_home | default('true') }}"
+        home: "{{ galaxy_privsep_user.home | default(omit) }}"
+        shell: "{{ galaxy_privsep_user.shell | default(omit) }}"
+        system: "{{ galaxy_privsep_user.system | default('true') }}"
+        local: "{{ galaxy_privsep_user.local | default(omit) }}"
+      when: galaxy_create_privsep_user
+
+  remote_user: "{{ galaxy_remote_users.root | default(omit) }}"
+  become: "{{ galaxy_become_users.root is not undefined }}"
+  become_user: "{{ galaxy_become_users.root | default(omit) }}"

--- a/tests/test_playbook.yml
+++ b/tests/test_playbook.yml
@@ -6,11 +6,22 @@
   connection: local
   remote_user: travis
   vars:
-    galaxy_commit_id: release_18.05
+    galaxy_commit_id: release_18.09
+    galaxy_create_user: yes
+    galaxy_manage_paths: yes
     galaxy_manage_clone: yes
     galaxy_manage_download: no
-    galaxy_server_dir: /home/galaxy/server
     galaxy_config_style: yaml
+    galaxy_layout: root-dir
+    galaxy_root: /srv/galaxy
+    galaxy_separate_privileges: yes
+    galaxy_user: galaxy
+    galaxy_privsep_user: gxpriv
+    galaxy_config:
+      galaxy:
+        database_connection: sqlite:///{{ galaxy_mutable_data_dir }}/universe.sqlite
+    # needed because we've disabled facts
+    ansible_user_uid: "{{ lookup('env', 'UID') }}"
+    ansible_user_id: "{{ lookup('env', 'USER') }}"
   roles:
     - role: ansible-galaxy
-      become: yes


### PR DESCRIPTION
This should further simplify using this role to perform a "best practices" deployment and get rid of a bunch of `pre_tasks` that were required for such a deployment. It should no longer be necessary to run this role more than once.

Sorry for even more new vars @erasche :sweat: 