### PR TITLE
Potential simplification for dir permissions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,6 +81,8 @@ __galaxy_privsep_user_name: "{{ galaxy_privsep_user.name | default(galaxy_privse
 
 # If `galaxy_create_user` is enabled, the privsep user will also be created, but you can override this behavior
 galaxy_create_privsep_user: "{{ galaxy_create_user if __galaxy_privsep_user_name != 'root' else false }}"
+# Set galaxy root directory permissions. This nearly always needs to be world readable to nginx can read the static artifacts.
+__galaxy_dir_perms: 0755
 
 # Directories to create as the Galaxy user if galaxy_manage_paths is enabled
 galaxy_dirs:

--- a/tasks/paths.yml
+++ b/tasks/paths.yml
@@ -28,10 +28,6 @@
         __galaxy_user_group: "{{ ((galaxy_group | default({})).name | default(galaxy_group)) if galaxy_group is defined else (__galaxy_group_result.results[0].ansible_facts.getent_group.keys() | first) }}"
         __galaxy_privsep_user_group: "{{ ((galaxy_group | default({})).name | default(galaxy_group)) if galaxy_group is defined else (__galaxy_group_result.results[1].ansible_facts.getent_group.keys() | first) }}"
 
-    - name: Determine whether to restrict to group permissions
-      set_fact:
-        __galaxy_dir_perms: "{{ '0750' if __galaxy_user_group == __galaxy_privsep_user_group else '0755' }}"
-
     # try to become root. if you need something fancier, don't use the role and write your own
     - name: Create galaxy_root
       file:


### PR DESCRIPTION
When trying to do priv sep, it's restricted enough that nginx cannot access static files. While adding nginx to the galaxy group is one option, it can be a bit messy in ansible? Maybe this just makes things easier?