### PR TITLE
Allow clone depth to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ Options for configuring Galaxy and controlling which version is installed.
   updated to. Specifying a branch will update to the latest commit on that branch. Using a real commit id is the only
   way to explicitly lock Galaxy at a specific version.
 - `galaxy_force_checkout` (default: `no`): If `yes`, any modified files in the Galaxy repository will be discarded.
+- `galaxy_clone_depth` (default: `null`): Depth to use when performing git clone. Leave unspecified to clone entire
+   history.
 
 **Path configuration**
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -124,6 +124,9 @@ galaxy_repo: "{{ galaxy_git_repo | default('https://github.com/galaxyproject/gal
 # Automatically delete things in the repo that do not belong there
 galaxy_force_checkout: no
 
+# Git clone depth for the galaxy repository. Leave blank to ignore.
+galaxy_clone_depth:
+
 # This can be a tag (as shown here) but doing so will cause the revision check task to always report "changed".
 # Backwards compatibility with galaxy_changeset_id.
 galaxy_commit_id: "{{ galaxy_changeset_id | default('master') }}"

--- a/tasks/clone.yml
+++ b/tasks/clone.yml
@@ -8,6 +8,7 @@
       git:
         dest: "{{ galaxy_server_dir }}"
         force: "{{ galaxy_force_checkout }}"
+        depth: "{{ galaxy_clone_depth }}"
         repo: "{{ galaxy_repo }}"
         version: "{{ galaxy_commit_id }}"
         executable: "{{ git_executable | default(omit) }}"


### PR DESCRIPTION
Specifying the depth speeds things up quite a bit. Have left the defaults as is to clone the entire history.