### PR TITLE
Don't attempt to instantiate mutable configs from samples on >= 19.09.

### DIFF
--- a/tasks/_inc_galaxy_version.yml
+++ b/tasks/_inc_galaxy_version.yml
@@ -1,0 +1,18 @@
+---
+# Determine Galaxy version
+
+# Currently only used by mutable config setup but placed in an include because it'll probably be used by more
+
+- name: Collect Galaxy version file
+  slurp:
+    src: "{{ galaxy_server_dir }}/lib/galaxy/version.py"
+  register: __galaxy_version_file
+
+- name: Determine Galaxy version
+  set_fact:
+    __galaxy_major_version: >-
+        {{
+            (__galaxy_version_file['content'] | b64decode).splitlines()
+                | select('match', 'VERSION_MAJOR\s*=.*') | first
+                | regex_replace('^[^\d]+([.\d]+).*', '\1')
+        }}

--- a/tasks/mutable_setup.yml
+++ b/tasks/mutable_setup.yml
@@ -4,6 +4,10 @@
 - name: Mutable config setup
   block:
 
+    - name: Ensure Galaxy version is set
+      include_tasks: _inc_galaxy_version.yml
+      when: __galaxy_major_version is undefined
+
     - name: Create mutable configuration file directories
       file:
         path: "{{ item }}"
@@ -17,6 +21,7 @@
       args:
         creates: "{{ item.dest }}"
       with_items: "{{ galaxy_mutable_configs }}"
+      when: __galaxy_major_version is version('19.09', '<')
 
     - name: Template mutable configuration files
       template:


### PR DESCRIPTION
Fixes #81.