### PR TITLE
Automatically set galaxy_node_version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -115,8 +115,8 @@ galaxy_dynamic_job_rules: []
 # Version control
 #
 
-# TODO: This needs to be read from Galaxy. Until we have a good solution for that, this is valid for 18.09 and older.
-galaxy_node_version: "9.11.1"
+# This is now automatically determined in tasks/_inc_node_version.yml, but it can be set to force a version
+#galaxy_node_version: "XX.YY.Z"
 
 # Where to clone Galaxy from. Backwards compatibility with galaxy_git_repo
 galaxy_repo: "{{ galaxy_git_repo | default('https://github.com/galaxyproject/galaxy.git') }}"

--- a/tasks/_inc_node_version.yml
+++ b/tasks/_inc_node_version.yml
@@ -15,7 +15,7 @@
 
     - name: Set Galaxy Node.js version fact
       set_fact:
-        galaxy_node_version: "{{ __galaxy_node_version_file['content'] | b64decode }}"
+        galaxy_node_version: "{{ __galaxy_node_version_file['content'] | b64decode | trim }}"
 
   rescue:
 

--- a/tasks/_inc_node_version.yml
+++ b/tasks/_inc_node_version.yml
@@ -1,0 +1,39 @@
+---
+# Determine preferred Node.js version
+
+# Galaxy 18.09 and older prefer 9.11.1
+# Galaxy 19.01 prefers 10.13.0
+# Galaxy 19.05 and newer provide client/.node_version
+
+- name: Determine preferred Node.js version
+  block:
+
+    - name: Collect Galaxy Node.js version file
+      slurp:
+        src: "{{ galaxy_server_dir }}/client/.node_version"
+      register: __galaxy_node_version_file
+
+    - name: Set Galaxy Node.js version fact
+      set_fact:
+        galaxy_node_version: "{{ __galaxy_node_version_file['content'] | b64decode }}"
+
+  rescue:
+
+    - name: Ensure Galaxy version is set
+      include_tasks: _inc_galaxy_version.yml
+      when: __galaxy_major_version is undefined
+
+    - name: Sanity check whether .node_version should be present
+      assert:
+        that:
+          - __galaxy_major_version is version('19.09', '<')
+        fail_msg: "Galaxy version {{ __galaxy_major_version }} >= 19.09 but client/.node_version file missing!"
+        success_msg: "Galaxy version {{ __galaxy_major_version }} < 19.09, will use hardcoded Node.js version default"
+
+    - name: Set Galaxy Node.js version fact
+      set_fact:
+        galaxy_node_version: "{{ '9.11.1' if (__galaxy_major_version is version('19.01', '<')) else '10.13.0' }}"
+
+- name: Report preferred Node.js version
+  debug:
+    var: galaxy_node_version

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -50,6 +50,10 @@
           changed_when: true
           when: __galaxy_from_git.stat.exists
 
+        - name: Ensure galaxy_node_version is set
+          include_tasks: _inc_node_version.yml
+          when: galaxy_node_version is undefined
+
         - name: Install node
           command: "nodeenv -n {{ galaxy_node_version }} -p"
           environment:


### PR DESCRIPTION
I also considered that we could just commit `client/.node_version` to old release branches, but then existing deployments would need to update Galaxy for this role not to fail if they updated the role.