### PR TITLE
Fix blanking of remote/become user by privilege separation vars

### DIFF
--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -97,6 +97,6 @@
 
       when: not __galaxy_from_git.stat.exists or (__galaxy_client_build_version != __galaxy_current_commit_id)
 
-  remote_user: "{{ galaxy_remote_users.privsep | default(omit) }}"
+  remote_user: "{{ galaxy_remote_users.privsep | default(__galaxy_remote_user) }}"
   become: "{{ true if galaxy_become_users.privsep is defined else __galaxy_become }}"
-  become_user: "{{ galaxy_become_users.privsep | default(ansible_user_id) }}"
+  become_user: "{{ galaxy_become_users.privsep | default(__galaxy_become_user) }}"

--- a/tasks/clone.yml
+++ b/tasks/clone.yml
@@ -31,6 +31,6 @@
         PATH: "{{ galaxy_venv_dir }}/bin"
       when: __galaxy_git_update_result is changed
 
-  remote_user: "{{ galaxy_remote_users.privsep | default(omit) }}"
+  remote_user: "{{ galaxy_remote_users.privsep | default(__galaxy_remote_user) }}"
   become: "{{ true if galaxy_become_users.privsep is defined else __galaxy_become }}"
-  become_user: "{{ galaxy_become_users.privsep | default(ansible_user_id) }}"
+  become_user: "{{ galaxy_become_users.privsep | default(__galaxy_become_user) }}"

--- a/tasks/database.yml
+++ b/tasks/database.yml
@@ -39,6 +39,6 @@
         chdir: "{{ galaxy_server_dir }}"
       when: "(not ansible_check_mode) and current_db_version.stdout != max_db_version.stdout and 'migrate.exceptions.DatabaseNotControlledError' not in current_db_version.stderr"
 
-  remote_user: "{{ galaxy_remote_users.galaxy | default(omit) }}"
+  remote_user: "{{ galaxy_remote_users.galaxy | default(__galaxy_remote_user) }}"
   become: "{{ true if galaxy_become_users.galaxy is defined else __galaxy_become }}"
-  become_user: "{{ galaxy_become_users.galaxy | default(ansible_user_id) }}"
+  become_user: "{{ galaxy_become_users.galaxy | default(__galaxy_become_user) }}"

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -36,6 +36,6 @@
         VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
       when: (not ansible_check_mode) and conditional_dependencies.stdout_lines | length > 0
 
-  remote_user: "{{ galaxy_remote_users.privsep | default(omit) }}"
+  remote_user: "{{ galaxy_remote_users.privsep | default(__galaxy_remote_user) }}"
   become: "{{ true if galaxy_become_users.privsep is defined else __galaxy_become }}"
-  become_user: "{{ galaxy_become_users.privsep | default(ansible_user_id) }}"
+  become_user: "{{ galaxy_become_users.privsep | default(__galaxy_become_user) }}"

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -36,6 +36,6 @@
       environment:
         PATH: "{{ galaxy_venv_dir }}/bin"
 
-  remote_user: "{{ galaxy_remote_users.privsep | default(omit) }}"
+  remote_user: "{{ galaxy_remote_users.privsep | default(__galaxy_remote_user) }}"
   become: "{{ true if galaxy_become_users.privsep is defined else __galaxy_become }}"
-  become_user: "{{ galaxy_become_users.privsep | default(ansible_user_id) }}"
+  become_user: "{{ galaxy_become_users.privsep | default(__galaxy_become_user) }}"

--- a/tasks/errordocs.yml
+++ b/tasks/errordocs.yml
@@ -38,6 +38,6 @@
         state: link
         force: yes
 
-  remote_user: "{{ galaxy_remote_users.errdocs | default(omit) }}"
+  remote_user: "{{ galaxy_remote_users.errdocs | default(__galaxy_remote_user) }}"
   become: "{{ true if galaxy_become_users.errdocs is defined else __galaxy_become }}"
-  become_user: "{{ galaxy_become_users.errdocs | default(ansible_user_id) }}"
+  become_user: "{{ galaxy_become_users.errdocs | default(__galaxy_become_user) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,9 +12,11 @@
 # To my knowledge there is no other way to know whether or not the consumer of this role has set `become: true` outside
 # this role, and `become: {{ foo | default(omit) }}` on a task/block actually clobbers the higher level use of `become`.
 # This is a temporary solution.
-- name: Determine if become is in use
+- name: Set privilege separation default variables
   set_fact:
+    __galaxy_remote_user: "{{ ansible_user | default(omit) }}"
     __galaxy_become: "{{ ansible_env.SUDO_USER is defined }}"
+    __galaxy_become_user: "{{ ansible_user_id | default(omit) }}"
 
 - name: Import layout variable tasks
   import_tasks: layout.yml

--- a/tasks/mutable_setup.yml
+++ b/tasks/mutable_setup.yml
@@ -30,6 +30,6 @@
           force: no # Will not template, if already exists. https://docs.ansible.com/ansible/latest/modules/template_module.html
       with_items: "{{ galaxy_mutable_config_templates }}"
 
-  remote_user: "{{ galaxy_remote_users.galaxy | default(omit) }}"
+  remote_user: "{{ galaxy_remote_users.galaxy | default(__galaxy_remote_user) }}"
   become: "{{ true if galaxy_become_users.galaxy is defined else __galaxy_become }}"
-  become_user: "{{ galaxy_become_users.galaxy | default(ansible_user_id) }}"
+  become_user: "{{ galaxy_become_users.galaxy | default(__galaxy_become_user) }}"

--- a/tasks/paths.yml
+++ b/tasks/paths.yml
@@ -61,6 +61,6 @@
       with_items: "{{ galaxy_dirs }}"
 
   # TODO: for root squashing it might be useful for this to be separate from other root tasks
-  remote_user: "{{ galaxy_remote_users.root | default(omit) }}"
+  remote_user: "{{ galaxy_remote_users.root | default(__galaxy_remote_user) }}"
   become: "{{ true if galaxy_become_users.root is defined else __galaxy_become }}"
-  become_user: "{{ galaxy_become_users.root | default(ansible_user_id) }}"
+  become_user: "{{ galaxy_become_users.root | default(__galaxy_become_user) }}"

--- a/tasks/static_setup.yml
+++ b/tasks/static_setup.yml
@@ -79,6 +79,6 @@
       notify:
         - "{{ galaxy_restart_handler_name | default('default restart galaxy handler') }}"
 
-  remote_user: "{{ galaxy_remote_users.privsep | default(omit) }}"
+  remote_user: "{{ galaxy_remote_users.privsep | default(__galaxy_remote_user) }}"
   become: "{{ true if galaxy_become_users.privsep is defined else __galaxy_become }}"
-  become_user: "{{ galaxy_become_users.privsep | default(ansible_user_id) }}"
+  become_user: "{{ galaxy_become_users.privsep | default(__galaxy_become_user) }}"

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -37,6 +37,6 @@
         local: "{{ galaxy_privsep_user.local | default(omit) }}"
       when: galaxy_create_privsep_user
 
-  remote_user: "{{ galaxy_remote_users.root | default(omit) }}"
+  remote_user: "{{ galaxy_remote_users.root | default(__galaxy_remote_user) }}"
   become: "{{ true if galaxy_become_users.root is defined else __galaxy_become }}"
-  become_user: "{{ galaxy_become_users.root | default(ansible_user_id) }}"
+  become_user: "{{ galaxy_become_users.root | default(__galaxy_become_user) }}"


### PR DESCRIPTION
Even if you weren't using privsep mode, the use of `omit` when `galaxy_remote_users.*` were unset meant that Ansible would attempt to connect without any remote username, even if one was set or configured at a higher level.