### PR TITLE
Deconstruct client build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - sudo apt-get install git
 
   # Install Ansible
-  - pip install ansible==2.5
+  - pip install 'ansible<2.8'
 
   # Add ansible.cfg to pick up roles path
   - printf '[defaults]\nroles_path = ../' > ansible.cfg

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -256,8 +256,7 @@ galaxy_uwsgi_config_default:
 # Client build settings
 #
 
-# Set galaxy_client_make_target to use Galaxy's provided Makefile for building the client. By default, these are
-# implemented as separate Ansible tasks for greater transparency
-# Options include: client / client-production / client-production-maps (default)
-#galaxy_client_make_target: client-production-maps
+# Options include: client / client-production / client-production-maps (default). Set to null to invoke each step of the
+# build separately, but this is not guaranteed to work for all version of Galaxy - using `make` is the safer choice.
+galaxy_client_make_target: client-production-maps
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -256,6 +256,8 @@ galaxy_uwsgi_config_default:
 # Client build settings
 #
 
+# Set galaxy_client_make_target to use Galaxy's provided Makefile for building the client. By default, these are
+# implemented as separate Ansible tasks for greater transparency
 # Options include: client / client-production / client-production-maps (default)
-galaxy_client_make_target: client-production-maps
+#galaxy_client_make_target: client-production-maps
 

--- a/tasks/_inc_client_build_make.yml
+++ b/tasks/_inc_client_build_make.yml
@@ -1,0 +1,25 @@
+---
+
+- name: Build client
+  make:
+    chdir: "{{ galaxy_server_dir }}"
+    target: "{{ galaxy_client_make_target }}"
+  environment:
+    PATH: "{{ galaxy_venv_dir }}/bin:{{ ansible_env.PATH }}"
+    VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+
+- name: Fetch client version
+  slurp:
+    src: "{{ galaxy_static_dir }}/client_build_hash.txt"
+  register: __galaxy_client_build_version_result
+
+- name: Set client build version fact
+  set_fact:
+    __galaxy_client_build_version: "{{ __galaxy_client_build_version_result.content | b64decode | trim }}"
+
+- name: Ensure that client update succeeded
+  assert:
+    that:
+      - __galaxy_client_build_version == __galaxy_current_commit_id
+    msg: "Client build version does not match repo version after building: {{ __galaxy_client_build_version }} != {{ __galaxy_current_commit_id }}"
+  when: __galaxy_from_git.stat.exists

--- a/tasks/_inc_client_build_steps.yml
+++ b/tasks/_inc_client_build_steps.yml
@@ -9,16 +9,20 @@
     VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
 
 - name: Run gulp
-  command: gulp
+  command: yarn run gulp {{ item }}
   args:
     chdir: "{{ galaxy_server_dir }}/client"
+  with_items:
+    - fonts
+    - stageLibs
+    - plugins
   environment:
     PATH: "{{ galaxy_server_dir }}/client/node_modules/.bin:{{ galaxy_venv_dir }}/bin:{{ ansible_env.PATH }}"
     VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
     NODE_ENV: production
 
 - name: Run webpack
-  command: webpack -p
+  command: yarn run webpack-production
   args:
     chdir: "{{ galaxy_server_dir }}/client"
   environment:

--- a/tasks/_inc_client_build_steps.yml
+++ b/tasks/_inc_client_build_steps.yml
@@ -1,0 +1,32 @@
+---
+
+- name: Install packages with yarn
+  yarn:
+    executable: "yarn --network-timeout 300000 --check-files"
+    path: "{{ galaxy_server_dir }}/client"
+  environment:
+    PATH: "{{ galaxy_venv_dir }}/bin:{{ ansible_env.PATH }}"
+    VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+
+- name: Run gulp
+  command: gulp
+  args:
+    chdir: "{{ galaxy_server_dir }}/client"
+  environment:
+    PATH: "{{ galaxy_server_dir }}/client/node_modules/.bin:{{ galaxy_venv_dir }}/bin:{{ ansible_env.PATH }}"
+    VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+    NODE_ENV: production
+
+- name: Run webpack
+  command: webpack -p
+  args:
+    chdir: "{{ galaxy_server_dir }}/client"
+  environment:
+    PATH: "{{ galaxy_server_dir }}/client/node_modules/.bin:{{ galaxy_venv_dir }}/bin:{{ ansible_env.PATH }}"
+    VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+    GXY_BUILD_SOURCEMAPS: 1
+
+- name: Store client version
+  copy:
+    content: "{{ __galaxy_current_commit_id }}"
+    dest: "{{ galaxy_static_dir }}/client_build_hash.txt"

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -33,13 +33,8 @@
 
     - name: Set client build version fact
       set_fact:
-        __galaxy_current_commit_id: "{{ __galaxy_git_stat_result.after }}"
+        __galaxy_current_commit_id: "{{ __galaxy_git_stat_result.after if __galaxy_from_git.stat.exists else 'none' }}"
       when: __galaxy_from_git.stat.exists
-
-    - name: Set client build version fact
-      set_fact:
-        __galaxy_current_commit_id: "none"
-      when: not __galaxy_from_git.stat.exists
 
     - name: Build Galaxy client if needed
       block:
@@ -71,29 +66,8 @@
             PATH: "{{ galaxy_venv_dir }}/bin:{{ ansible_env.PATH }}"
             VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
 
-        - name: Build client
-          make:
-            chdir: "{{ galaxy_server_dir }}"
-            target: "{{ galaxy_client_make_target }}"
-          environment:
-            PATH: "{{ galaxy_venv_dir }}/bin:{{ ansible_env.PATH }}"
-            VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
-
-        - name: Fetch client version
-          slurp:
-            src: "{{ galaxy_static_dir }}/client_build_hash.txt"
-          register: __galaxy_client_build_version_result
-
-        - name: Set client build version fact
-          set_fact:
-            __galaxy_client_build_version: "{{ __galaxy_client_build_version_result.content | b64decode | trim }}"
-
-        - name: Ensure that client update succeeded
-          assert:
-            that:
-              - __galaxy_client_build_version == __galaxy_current_commit_id
-            msg: "Client build version does not match repo version after building: {{ __galaxy_client_build_version }} != {{ __galaxy_current_commit_id }}"
-          when: __galaxy_from_git.stat.exists
+        - name: Include client build process
+          import_tasks: "_inc_client_build_{{ 'make' if galaxy_client_make_target is defined else 'steps' }}.yml"
 
       when: not __galaxy_from_git.stat.exists or (__galaxy_client_build_version != __galaxy_current_commit_id)
 

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -67,7 +67,7 @@
             VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
 
         - name: Include client build process
-          import_tasks: "_inc_client_build_{{ 'make' if galaxy_client_make_target is defined else 'steps' }}.yml"
+          import_tasks: "_inc_client_build_{{ 'make' if galaxy_client_make_target | bool else 'steps' }}.yml"
 
       when: not __galaxy_from_git.stat.exists or (__galaxy_client_build_version != __galaxy_current_commit_id)
 

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -67,7 +67,7 @@
             VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
 
         - name: Include client build process
-          import_tasks: "_inc_client_build_{{ 'make' if galaxy_client_make_target | bool else 'steps' }}.yml"
+          import_tasks: "_inc_client_build_{{ 'make' if galaxy_client_make_target else 'steps' }}.yml"
 
       when: not __galaxy_from_git.stat.exists or (__galaxy_client_build_version != __galaxy_current_commit_id)
 

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -67,7 +67,7 @@
             VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
 
         - name: Include client build process
-          import_tasks: "_inc_client_build_{{ 'make' if galaxy_client_make_target else 'steps' }}.yml"
+          include_tasks: "_inc_client_build_{{ 'make' if galaxy_client_make_target is not none else 'steps' }}.yml"
 
       when: not __galaxy_from_git.stat.exists or (__galaxy_client_build_version != __galaxy_current_commit_id)
 


### PR DESCRIPTION
This adds some transparency for the admin but requires us to synchronize with the client build scripts and will be complicated by differences across versions. Because of that, the default is still to invoke `make client-production-maps`.