### PR TITLE
Clone depth 

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ Options for configuring Galaxy and controlling which version is installed.
   updated to. Specifying a branch will update to the latest commit on that branch. Using a real commit id is the only
   way to explicitly lock Galaxy at a specific version.
 - `galaxy_force_checkout` (default: `no`): If `yes`, any modified files in the Galaxy repository will be discarded.
+- `galaxy_clone_depth` (default: `null`): Depth to use when performing git clone. Leave unspecified to clone entire
+   history.
 
 **Path configuration**
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Options for configuring Galaxy and controlling which version is installed.
   updated to. Specifying a branch will update to the latest commit on that branch. Using a real commit id is the only
   way to explicitly lock Galaxy at a specific version.
 - `galaxy_force_checkout` (default: `no`): If `yes`, any modified files in the Galaxy repository will be discarded.
-- `galaxy_clone_depth` (default: `null`): Depth to use when performing git clone. Leave unspecified to clone entire
+- `galaxy_clone_depth` (default: unset): Depth to use when performing git clone. Leave unspecified to clone entire
    history.
 
 **Path configuration**

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -124,6 +124,9 @@ galaxy_repo: "{{ galaxy_git_repo | default('https://github.com/galaxyproject/gal
 # Automatically delete things in the repo that do not belong there
 galaxy_force_checkout: no
 
+# Git clone depth for the galaxy repository. Leave blank to ignore.
+galaxy_clone_depth:
+
 # This can be a tag (as shown here) but doing so will cause the revision check task to always report "changed".
 # Backwards compatibility with galaxy_changeset_id.
 galaxy_commit_id: "{{ galaxy_changeset_id | default('master') }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -124,8 +124,8 @@ galaxy_repo: "{{ galaxy_git_repo | default('https://github.com/galaxyproject/gal
 # Automatically delete things in the repo that do not belong there
 galaxy_force_checkout: no
 
-# Git clone depth for the galaxy repository. Leave blank to ignore.
-galaxy_clone_depth:
+# Git clone depth for the galaxy repository. Leave unset to ignore.
+#galaxy_clone_depth:
 
 # This can be a tag (as shown here) but doing so will cause the revision check task to always report "changed".
 # Backwards compatibility with galaxy_changeset_id.

--- a/tasks/clone.yml
+++ b/tasks/clone.yml
@@ -8,6 +8,7 @@
       git:
         dest: "{{ galaxy_server_dir }}"
         force: "{{ galaxy_force_checkout }}"
+        depth: "{{ galaxy_clone_depth }}"
         repo: "{{ galaxy_repo }}"
         version: "{{ galaxy_commit_id }}"
         executable: "{{ git_executable | default(omit) }}"

--- a/tasks/clone.yml
+++ b/tasks/clone.yml
@@ -8,7 +8,7 @@
       git:
         dest: "{{ galaxy_server_dir }}"
         force: "{{ galaxy_force_checkout }}"
-        depth: "{{ galaxy_clone_depth }}"
+        depth: "{{ galaxy_clone_depth | default(omit) }}"
         repo: "{{ galaxy_repo }}"
         version: "{{ galaxy_commit_id }}"
         executable: "{{ git_executable | default(omit) }}"


### PR DESCRIPTION
Can't commit the changes @natefoo recommended to #74 so opening a new PR.

In my testing for planemo-machine it was faster to just download a tarball and then we wouldn't need to clean it up git stuff after (https://github.com/galaxyproject/planemo-machine/blob/master/group_vars/all#L29)... but that is a bigger change.