### PR TITLE
Install libyaml version of uwsgi when galaxy_uwsgi_yaml_parser == libyaml

### DIFF
--- a/files/libyaml.ini
+++ b/files/libyaml.ini
@@ -1,0 +1,27 @@
+# Settings for compiling libyaml version of UWSGI
+[uwsgi]
+main_plugin = python,gevent
+xml = auto
+yaml = libyaml
+json = auto
+ssl = auto
+pcre = auto
+routing = auto
+debug = false
+unbit = false
+malloc_implementation = libc
+extras =
+plugins =
+bin_name = uwsgi
+append_version =
+plugin_dir = .
+embedded_plugins = %(main_plugin)s, ping, cache, nagios, rrdtool, carbon, rpc, corerouter, fastrouter, http, ugreen, signal, syslog, rsyslog, logsocket, router_uwsgi, router_redirect, router_basicauth, zergpool, redislog, mongodblog, router_rewrite, router_http, logfile, router_cache, rawrouter, router_static, sslrouter, spooler, cheaper_busyness, symcall, transformation_tofile, transformation_gzip, transformation_chunked, transformation_offload, router_memcached, router_redis, router_hash, router_expires, router_metrics, transformation_template, stats_pusher_socket
+as_shared_library = false
+locking = auto
+event = auto
+timer = auto
+filemonitor = auto
+blacklist =
+whitelist =
+embed_files =
+embed_config =

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -7,6 +7,12 @@
     - name: Include virtualenv setup tasks
       import_tasks: virtualenv.yml
 
+    - name: Copy libyaml.ini file
+      copy:
+        src: "libyaml.ini"
+        dest: "{{ galaxy_config_dir }}/libyaml.ini"
+      when: galaxy_uwsgi_yaml_parser == "libyaml"
+
     # virtualenv_command is still required if `virtualenv` isn't on $PATH, even if the venv already exists.
     - name: Install Galaxy base dependencies
       pip:
@@ -17,6 +23,13 @@
       environment:
         PYTHONPATH: null
         VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+        UWSGI_PROFILE: "{{ (galaxy_config_dir + '/libyaml.ini') if galaxy_uwsgi_yaml_parser == 'libyaml' else '' }}"
+
+    - name: Remove libyaml.ini
+      file:
+        state: absent
+        path: "{{ galaxy_config_dir }}/libyaml.ini"
+      when: galaxy_uwsgi_yaml_parser == "libyaml"
 
     - name: Collect Galaxy conditional dependency requirement strings
       command: "{{ galaxy_venv_dir }}/bin/python -c \"import galaxy.dependencies; print('\\n'.join(galaxy.dependencies.optional('{{ galaxy_config_file }}')))\""

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -7,12 +7,6 @@
     - name: Include virtualenv setup tasks
       import_tasks: virtualenv.yml
 
-    - name: Copy libyaml.ini file
-      copy:
-        src: "libyaml.ini"
-        dest: "{{ galaxy_config_dir }}/libyaml.ini"
-      when: galaxy_uwsgi_yaml_parser == "libyaml"
-
     # virtualenv_command is still required if `virtualenv` isn't on $PATH, even if the venv already exists.
     - name: Install Galaxy base dependencies
       pip:
@@ -23,7 +17,31 @@
       environment:
         PYTHONPATH: null
         VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
-        UWSGI_PROFILE: "{{ (galaxy_config_dir + '/libyaml.ini') if galaxy_uwsgi_yaml_parser == 'libyaml' else '' }}"
+
+    # recompile uwsgi with libyaml when galaxy_uwsgi_yaml_parser == 'libyaml'
+    # xref: https://github.com/galaxyproject/galaxy/issues/8558
+    - name: Copy libyaml.ini file
+      copy:
+        src: "libyaml.ini"
+        dest: "{{ galaxy_config_dir }}/libyaml.ini"
+      when: galaxy_uwsgi_yaml_parser == "libyaml"
+
+    - name: Get currently installed version of uwsgi
+      shell: "{{ galaxy_venv_dir }}/bin/uwsgi --version"
+      register: uwsgi_output
+      when: galaxy_uwsgi_yaml_parser == "libyaml"
+
+    - name: Install same version of uwsgi as in galaxy requirements, but with libyaml (libyaml-dev package required)
+      pip:
+        name: "uwsgi=={{ uwsgi_output.stdout }}"
+        extra_args: "{{ pip_extra_args | default('') }}"
+        virtualenv: "{{ galaxy_venv_dir }}"
+        virtualenv_command: "{{ galaxy_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
+      environment:
+        PYTHONPATH: null
+        VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+        UWSGI_PROFILE: "{{ galaxy_config_dir }}/libyaml.ini"
+      when: galaxy_uwsgi_yaml_parser == "libyaml"
 
     - name: Remove libyaml.ini
       file:


### PR DESCRIPTION
**Background**
The original issue is detailed here: https://github.com/galaxyproject/galaxy/issues/8558

The TL; DR; version is that uwsgi has two config parsers, an internal parser (which uses an invalid yaml format) and a libyaml based parser (valid yaml but requires manual compilation with libyaml because the wheel version defaults to the internal parser).

**This PR**
Since we needed a valid yaml format for the k8s docker container, the original plan that was hatched in that issue was to make the required changes in the k8s Dockerfile here: https://github.com/CloudVE/galaxy-docker-k8s/pull/11. However, @almahmoud  later pointed out that  there was in fact a setting specifying that libyaml should be used for configs: `galaxy_uwsgi_yaml_parser`. If that setting is used for configs, we should clearly install the compatible libyaml, so we then thought that it's better to make the modification in ansible-galaxy itself.

We thought we'd found a nice and compact way to implement the solution: https://github.com/galaxyproject/ansible-galaxy/commit/b632350b4896d0283964036ed7baae853c757589, except for the minor detail that it didn't work because the galaxy index server only has the pyuwsgi wheel, and I don't know how you can get a source-compilable version to sit alongside it.

So unless @natefoo has some magic he could work here, the current PR contains a slightly lengthier workaround: https://github.com/galaxyproject/ansible-galaxy/commit/06fa8585ec69d7ff7a53beb7e02f748bda677570
