### PR TITLE
Add missing conf file templates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -219,9 +219,9 @@ galaxy_mutable_config_templates:
   - src: "shed_tool_conf.xml"
     dest: "{{ galaxy_shed_tool_conf_file }}"
   - src: "shed_data_manager_conf.xml"
-    dest: "{{ galaxy_server_dir }}/config/shed_data_manager_conf.xml"
+    dest: "{{ galaxy_mutable_config_dir }}/shed_data_manager_conf.xml"
   - src: "shed_tool_data_table.xml"
-    dest: "{{ galaxy_server_dir }}/config/shed_tool_data_table_conf.xml"
+    dest: "{{ galaxy_mutable_config_dir }}/shed_tool_data_table_conf.xml"
 
 galaxy_config_error_email_to: "{{ galaxy_config_merged[galaxy_app_config_section].error_email_to | default('') }}"
 galaxy_config_instance_resource_url: "{{ galaxy_config_merged[galaxy_app_config_section].instance_resource_url | default('') }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -218,6 +218,10 @@ galaxy_mutable_configs:
 galaxy_mutable_config_templates:
   - src: "shed_tool_conf.xml"
     dest: "{{ galaxy_shed_tool_conf_file }}"
+  - src: "shed_data_manager_conf.xml"
+    dest: "{{ galaxy_server_dir }}/config/shed_data_manager_conf.xml"
+  - src: "shed_tool_data_table.xml"
+    dest: "{{ galaxy_server_dir }}/config/shed_tool_data_table_conf.xml"
 
 galaxy_config_error_email_to: "{{ galaxy_config_merged[galaxy_app_config_section].error_email_to | default('') }}"
 galaxy_config_instance_resource_url: "{{ galaxy_config_merged[galaxy_app_config_section].instance_resource_url | default('') }}"

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -34,3 +34,4 @@
   environment:
     PYTHONPATH: null
     VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+  when: ansible_python_version is version('3', '<')

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -24,3 +24,13 @@
   environment:
     PYTHONPATH: null
     VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+
+- name: pin setuptools to 44.0.0
+  pip:
+    name: setuptools
+    version: 44.0.0
+    virtualenv: "{{ galaxy_venv_dir }}"
+    virtualenv_command: "{{ galaxy_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
+  environment:
+    PYTHONPATH: null
+    VIRTUAL_ENV: "{{ galaxy_venv_dir }}"

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -34,4 +34,4 @@
   environment:
     PYTHONPATH: null
     VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
-  when: ansible_python_version is version('3', '<')
+  when: galaxy_venv_python is version('3', '<')

--- a/templates/shed_data_manager_conf.xml
+++ b/templates/shed_data_manager_conf.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<data_managers>
+</data_managers>

--- a/templates/shed_tool_data_table.xml
+++ b/templates/shed_tool_data_table.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<tables>
+</tables>

--- a/tests/test_playbook.yml
+++ b/tests/test_playbook.yml
@@ -2,7 +2,7 @@
 # Travis CI test playbook
 
 - hosts: localhost
-  gather_facts: False
+  gather_facts: True
   connection: local
   remote_user: travis
   vars:

--- a/tests/test_playbook.yml
+++ b/tests/test_playbook.yml
@@ -17,6 +17,7 @@
     galaxy_separate_privileges: yes
     galaxy_user: galaxy
     galaxy_privsep_user: gxpriv
+    galaxy_venv_python: 2.7
     galaxy_config:
       galaxy:
         database_connection: sqlite:///{{ galaxy_mutable_data_dir }}/universe.sqlite

--- a/tests/test_playbook.yml
+++ b/tests/test_playbook.yml
@@ -2,7 +2,7 @@
 # Travis CI test playbook
 
 - hosts: localhost
-  gather_facts: True
+  gather_facts: False
   connection: local
   remote_user: travis
   vars:


### PR DESCRIPTION
`shed_data_manager_conf.xml` and `shed_tool_data_table.xml` files were added in the template dir
and referenced in the ansible variable `galaxy_mutable_config_templates`.

Otherwise the server does not start using GalaxyKickStart. I suppose this would be the same with other means for deploying galaxy using this ansible role