### PR TITLE
Default to omitting the virtualenv command, and don't force it to follow the format `python...`

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,11 @@ Options for controlling where certain Galaxy components are placed on the filesy
 
 - `galaxy_venv_dir` (default: `<galaxy_server_dir>/.venv`): The role will create a [virtualenv][virtualenv] from which
   Galaxy will run, this controls where the virtualenv will be placed.
-- `galaxy_venv_python` (default: `2.7`): The python version to use when creating the virtualenv. Must be either 2.7, or 3.5 or higher.
+- `galaxy_virtualenv_command`: (default: `virtualenv`): The command used to create Galaxy's virtualenv. Set to `pyvenv`
+  to use Python 3 on Galaxy >= 20.01.
+- `galaxy_virtualenv_python`: (default: python of first `virtualenv` or `python` command on `$PATH`): The python binary
+  to use when creating the virtualenv. For Galaxy < 20.01, use python2.7 (if it is not the default), for Galaxy >=
+  20.01, use `python3.5` or higher.
 - `galaxy_config_dir` (default: `<galaxy_server_dir>`): Directory that will be used for "static" configuration files.
 - `galaxy_mutable_config_dir` (default: `<galaxy_server_dir>`): Directory that will be used for "mutable" configuration
   files, must be writable by the user running Galaxy.

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -10,7 +10,7 @@
     virtualenv: "{{ galaxy_venv_dir }}"
     extra_args: "{{ pip_extra_args | default('') }}"
     virtualenv_command: "{{ galaxy_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
-    virtualenv_python: "python{{ galaxy_venv_python | default('2.7') }}"
+    virtualenv_python: "{{ galaxy_virtualenv_python | default(omit) }}"
   environment:
     VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
 


### PR DESCRIPTION
This would impact galaxyproject/training-material#1659.

cc @hexylena 