### PR TITLE
Added support for using an existing Galaxy folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,11 @@ Several variables control which functions this role will perform (all default to
   superuser privileges.
 - `galaxy_manage_clone`: Clone Galaxy from the source repository and maintain it at a specified version (commit), as
   well as set up a [virtualenv][virtualenv] from which it can be run.
+- `galaxy_manage_download`: Download and unpack Galaxy from a remote archive url, as
+  well as set up a [virtualenv][virtualenv] from which it can be run.
+- `galaxy_manage_existing`: Take over a Galaxy directory that already exists, as
+  well as set up a [virtualenv][virtualenv] from which it can be run. `galaxy_server_dir` must point to the path which
+  already contains the source code of Galaxy.
 - `galaxy_manage_static_setup`: Manage "static" Galaxy configuration files - ones which are not modifiable by the Galaxy
   server itself. At a minimum, this is the primary Galaxy configuration file, `galaxy.ini`.
 - `galaxy_manage_mutable_setup`: Manage "mutable" Galaxy configuration files - ones which are modifiable by Galaxy (e.g.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ galaxy_create_user: no
 galaxy_manage_paths: no
 galaxy_manage_clone: yes
 galaxy_manage_download: no
+galaxy_manage_existing: no
 galaxy_manage_static_setup: yes
 galaxy_manage_mutable_setup: yes
 galaxy_manage_database: yes

--- a/tasks/existing.yml
+++ b/tasks/existing.yml
@@ -1,0 +1,28 @@
+---
+# Manage an existing Galaxy folder
+
+- name: Manage an existing Galaxy folder
+  block:
+
+    - name: Check for Galaxy server directory
+      stat:
+        path: "{{ galaxy_server_dir }}"
+      register: existing_dir_present
+
+    - name: Ensure that existing dir is present
+      assert:
+        that:
+          - existing_dir_present.stat.exists
+        fail_msg: "Specified existing Galaxy dir: {{ galaxy_server_dir }} not found."
+
+    - name: Include virtualenv setup tasks
+      import_tasks: virtualenv.yml
+
+    - name: Remove orphaned .pyc files and compile bytecode
+      script: makepyc.py {{ galaxy_server_dir }}/lib
+      environment:
+        PATH: "{{ galaxy_venv_dir }}/bin"
+
+  remote_user: "{{ galaxy_remote_users.privsep | default(__galaxy_remote_user) }}"
+  become: "{{ true if galaxy_become_users.privsep is defined else __galaxy_become }}"
+  become_user: "{{ galaxy_become_users.privsep | default(__galaxy_become_user) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,8 +7,9 @@
 - name: Ensure that mutually exclusive options are not set
   assert:
     that:
-      - not (galaxy_manage_clone and galaxy_manage_download)
-    fail_msg: "Variables galaxy_manage_clone and galaxy_manage_download cannot both be true."
+      - [galaxy_manage_clone | bool, galaxy_manage_download | bool, galaxy_manage_existing | bool].count(True) == 1
+    fail_msg: |
+      "Only one of variables galaxy_manage_clone, galaxy_manage_download and galaxy_manage_existing can be true."
 
 # To my knowledge there is no other way to know whether or not the consumer of this role has set `become: true` outside
 # this role, and `become: {{ foo | default(omit) }}` on a task/block actually clobbers the higher level use of `become`.
@@ -44,6 +45,11 @@
   include_tasks: download.yml
   when: galaxy_manage_download
   tags: galaxy_manage_download
+
+- name: Include manage existing galaxy tasks
+  include_tasks: existing.yml
+  when: galaxy_manage_existing
+  tags: galaxy_manage_existing
 
 - name: Include static config setup tasks
   include_tasks: static_setup.yml

--- a/tests/test_playbook.yml
+++ b/tests/test_playbook.yml
@@ -11,6 +11,7 @@
     galaxy_manage_paths: yes
     galaxy_manage_clone: yes
     galaxy_manage_download: no
+    galaxy_manage_existing: no
     galaxy_config_style: yaml
     galaxy_layout: root-dir
     galaxy_root: /srv/galaxy


### PR DESCRIPTION
Adds a new parameter, `galaxy_manage_existing`, which allows an existing galaxy directory to be reused, instead of cloning from git or downloading an archive. In this case, `galaxy_server_dir` is considered to be the existing directory. This is useful for building Docker images from the current folder.