### PR TITLE
Supply data_dir instead of individual cache dirs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -179,18 +179,7 @@ galaxy_app_config_default:
   tool_sheds_config_file: "{{ galaxy_server_dir }}/config/tool_sheds_conf.xml.sample"
 
   # Various cache and temporary directories
-  template_cache_path: "{{ galaxy_cache_dir }}/template_cache"
-  whoosh_index_dir: "{{ galaxy_cache_dir }}/whoosh_cache"
-  object_store_cache_path: "{{ galaxy_cache_dir }}/object_store_cache"
-  openid_consumer_cache_path: "{{ galaxy_cache_dir }}/openid_consumer_cache"
-  citation_cache_data_dir: "{{ galaxy_cache_dir }}/citations/data"
-  citation_cache_lock_dir: "{{ galaxy_cache_dir }}/citations/locks"
-  new_file_path: "{{ galaxy_mutable_data_dir }}/tmp"
-  mulled_resolution_cache_data_dir: "{{ galaxy_mutable_data_dir }}/mulled/data"
-  mulled_resolution_cache_lock_dir: "{{ galaxy_mutable_data_dir }}/mulled/lock"
-  tool_cache_data_dir: "{{ galaxy_cache_dir }}/tool_cache"
-  tool_search_index_dir: "{{ galaxy_cache_dir }}/tool_search_index"
-  container_image_cache_path: "{{ galaxy_cache_dir }}/container_cache"
+  data_dir: "{{ galaxy_mutable_data_dir }}"
 
   # Mutable config files
   integrated_tool_panel_config: "{{ galaxy_mutable_config_dir }}/integrated_tool_panel.xml"


### PR DESCRIPTION
Per discussion in https://github.com/galaxyproject/ansible-galaxy/commit/a0e933dd1f6422dfca66b5680fd91a717ee52836, this could be a better option for us where we're less likely to miss something.

That said, we lose the nice "cache" distinction. @natefoo what do you think. This is obviously without any migration path, and I can guess how you feel about that, likewise I don't want the mutable dir to suddenly double in size due to 2x copies of cache data.