### PR TITLE
Only create paths if they exist

### DIFF
--- a/tasks/paths.yml
+++ b/tasks/paths.yml
@@ -50,6 +50,7 @@
         group: "{{ __galaxy_privsep_user_group }}"
         mode: "{{ __galaxy_dir_perms }}"
       with_items: "{{ galaxy_privsep_dirs }}"
+      when: item | default(False)
 
     - name: Create additional directories
       file:


### PR DESCRIPTION
Some directories do not exist on the custom layout. I.e. have a `null` variable. (The local tool path I believe). And these directories can not be created. Using a `when: item | default(False)` will prevent these `null` directories from being included and created (which causes a crash).