### PR TITLE
Update setuptools as well as pip when creating a virtualenv.

### DIFF
--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -14,9 +14,11 @@
   environment:
     VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
 
-- name: Ensure pip is the latest release
+- name: Ensure pip and setuptools are the latest release
   pip:
-    name: pip
+    name: 
+      - pip
+      - setuptools
     state: latest
     extra_args: "{{ pip_extra_args | default('') }}"
     virtualenv: "{{ galaxy_venv_dir }}"


### PR DESCRIPTION
When a python from conda is used, this step prevents errors during the dependency installation phase.

This addition is necessary to work with conda python.