### PR TITLE
Support specification of ancillary configs in YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,40 @@ Options for configuring Galaxy and controlling which version is installed.
 - `galaxy_clone_depth` (default: unset): Depth to use when performing git clone. Leave unspecified to clone entire
    history.
 
+**Additional config files**
+
+Some optional configuration files commonly used in production Galaxy servers can be configured from variables:
+
+- `galaxy_dependency_resolvers`: Populate the `dependency_resolvers_conf.yml` file. See the [sample XML
+  configuration][dependency_resolvers_conf_sample] for options.
+- `galaxy_container_resolvers`: Populate the `container_resolvers_conf.yml` file. See the [sample XML
+  configuration][container_resolvers_conf_sample] for options.
+- `galaxy_job_metrics_plugins`: Populate the `job_metrics_conf.yml` file. See the [sample XML
+  configuration][job_metrics_conf_sample] for options.
+
+As of Galaxy 21.05 the sample configuration files for these features are in XML, but YAML is supported like so:
+
+```yaml
+galaxy_dependency_resolvers:
+  - type: <XML tag name>
+    <XML attribute name>: <XML attribute value>
+```
+
+For example:
+
+```yaml
+galaxy_dependency_resolvers:
+  - type: galaxy_packages
+  - type: conda
+    prefix: /srv/galaxy/conda
+    auto_init: true
+    auto_install: false
+```
+
+[dependency_resolvers_conf_sample]: https://github.com/galaxyproject/galaxy/blob/release_21.05/lib/galaxy/config/sample/dependency_resolvers_conf.xml.sample
+[container_resolvers_conf_sample]: https://github.com/galaxyproject/galaxy/blob/release_21.05/lib/galaxy/config/sample/container_resolvers_conf.xml.sample
+[job_metrics_conf_sample]: https://github.com/galaxyproject/galaxy/blob/release_21.05/lib/galaxy/config/sample/job_metrics_conf.xml.sample
+
 **Path configuration**
 
 Options for controlling where certain Galaxy components are placed on the filesystem.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -200,6 +200,9 @@ galaxy_app_config_default:
   tool_config_file: "{{ galaxy_tool_config_files | join(',') }}"
   shed_tool_config_file: "{{ galaxy_shed_tool_config_file }}"
 
+  # Static configs that default to .xml files in the config dir but the role writes as .yml if configured
+  job_metrics_config_file: "{{ galaxy_config_dir }}/job_metrics_conf.{{ 'yml' if galaxy_job_metrics_plugins is defined else 'xml' }}"
+
   # Everything else
   visualization_plugins_directory: "config/plugins/visualizations"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -201,7 +201,9 @@ galaxy_app_config_default:
   shed_tool_config_file: "{{ galaxy_shed_tool_config_file }}"
 
   # Static configs that default to .xml files in the config dir but the role writes as .yml if configured
-  job_metrics_config_file: "{{ galaxy_config_dir }}/job_metrics_conf.{{ 'yml' if galaxy_job_metrics_plugins is defined else 'xml' }}"
+  job_metrics_config_file: "{{ galaxy_config_dir }}/job_metrics_conf.{{ (galaxy_job_metrics_plugins is defined) | ternary('yml', 'xml') }}"
+  dependency_resolvers_config_file: "{{ galaxy_config_dir }}/dependency_resolvers_conf.{{ (galaxy_dependency_resolvers is defined) | ternary('yml', 'xml') }}"
+  containers_resolvers_config_file: "{{ (galaxy_container_resolvers is defined) | ternary(galaxy_config_dir ~ '/container_resolvers_conf.yml', none) }}"
 
   # Everything else
   visualization_plugins_directory: "config/plugins/visualizations"

--- a/tasks/static_setup.yml
+++ b/tasks/static_setup.yml
@@ -72,6 +72,16 @@
         label: "{{ galaxy_dynamic_job_rules_dir }}/{{ ((item | dirname) != '') | ternary ((item | dirname) ~ '/', '') }}__init__.py"
       with_items: "{{ galaxy_dynamic_job_rules }}"
 
+    - name: Create Galaxy Job Metrics configuration file
+      copy:
+        dest: "{{ galaxy_config_merged[galaxy_app_config_section].job_metrics_config_file }}"
+        content: |
+          ---
+          ## This file is managed by Ansible.  ALL CHANGES WILL BE OVERWRITTEN.
+          {{ galaxy_job_metrics_plugins | to_nice_yaml }}
+        mode: "0644"
+      when: galaxy_job_metrics_plugins is defined
+
     - name: Create Galaxy configuration file
       template:
         src: "{{ galaxy_config_file_template }}"

--- a/tasks/static_setup.yml
+++ b/tasks/static_setup.yml
@@ -72,7 +72,7 @@
         label: "{{ galaxy_dynamic_job_rules_dir }}/{{ ((item | dirname) != '') | ternary ((item | dirname) ~ '/', '') }}__init__.py"
       with_items: "{{ galaxy_dynamic_job_rules }}"
 
-    - name: Create Galaxy Job Metrics configuration file
+    - name: Create Galaxy job metrics configuration file
       copy:
         dest: "{{ galaxy_config_merged[galaxy_app_config_section].job_metrics_config_file }}"
         content: |
@@ -81,6 +81,26 @@
           {{ galaxy_job_metrics_plugins | to_nice_yaml }}
         mode: "0644"
       when: galaxy_job_metrics_plugins is defined
+
+    - name: Create Galaxy dependency resolvers configuration file
+      copy:
+        dest: "{{ galaxy_config_merged[galaxy_app_config_section].dependency_resolvers_config_file }}"
+        content: |
+          ---
+          ## This file is managed by Ansible.  ALL CHANGES WILL BE OVERWRITTEN.
+          {{ galaxy_dependency_resolvers | to_nice_yaml }}
+        mode: "0644"
+      when: galaxy_dependency_resolvers is defined
+
+    - name: Create Galaxy container resolvers configuration file
+      copy:
+        dest: "{{ galaxy_config_merged[galaxy_app_config_section].containers_resolvers_config_file }}"
+        content: |
+          ---
+          ## This file is managed by Ansible.  ALL CHANGES WILL BE OVERWRITTEN.
+          {{ galaxy_container_resolvers | to_nice_yaml }}
+        mode: "0644"
+      when: galaxy_container_resolvers is defined
 
     - name: Create Galaxy configuration file
       template:


### PR DESCRIPTION
This is done in a way that should be fairly unobtrusive to people already specifying these configs via `galaxy_config_files`, `galaxy_config_templates`, and `galaxy_config.galaxy.*`.

For example, simply setting the new `galaxy_job_metrics_plugins` var in your vars will create `{{ galaxy_config_dir }}/job_metrics_conf.yml` with the var contents, and set the corresponding path option in `galaxy.yml` (unless overridden by explicitly setting `galaxy_config.galaxy.job_metrics_config_file`). The var syntax matches the Galaxy YAML plugin syntax (which we need to document and provide examples for by converting `job_metrics_conf.xml.sample`).

I believe all the following should be supportable via this mechanism since they all use the plugin config lib:

- [x] job metrics
- [x] dependency resolvers
- [x] container resolvers

The Pulsar role has a syntax that is converted to XML that should probably be switched to this syntax instead. See galaxyproject/ansible-pulsar#19 for discussion and [here for an example](https://github.com/galaxyproject/usegalaxy-playbook/blob/4c0479deffad7e94bd8a30eccf897e0a093128a8/env/common/host_vars/vm030.bridges2.psc.edu.yml#L70) of the existing Pulsar role syntax in action.