### PR TITLE
Move systemd vars to individual vars to make them easier to override

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -277,17 +277,27 @@ galaxy_client_build_steps:
     - stageLibs
     - plugins
 
+# Restart handler is already set if using the systemd options in this role, otherwise you need to define one yourself
+galaxy_restart_handler_name: "{{ 'galaxy mule restart' if (galaxy_systemd_mode == 'mule' and galaxy_manage_systemd) else 'default restart galaxy handler' }}"
 
+#
 # systemd options
-galaxy_restart_handler_name: "{{ 'galaxy mule restart' if (galaxy_systemd.mode == 'mule' and galaxy_manage_systemd) else 'default restart galaxy handler' }}"
-galaxy_systemd:
-  env: "" #Any extra env vars
-  mode: mule
-  memory_limit:
-    mule: 16
-    reports: 5
-    #workflow: 5
-    #zergpool: 8
-    #zergling: 16
-    #handler: 5
-  stats: 4001 # Port for stats to listen on.
+#
+
+# Currently `mule` is the only systemd mode
+galaxy_systemd_mode: mule
+
+# Systemd will create cgroups to enforce these limits (sizes in GB), override individual limits by setting
+# `galaxy_systemd_memory_limit.<limit>` in your vars.
+__galaxy_systemd_memory_limit:
+  # This is for the entire group of uWSGI master, web worker, and mule processes
+  mule: 16
+  reports: 5
+  #workflow: 5
+  #zergpool: 8
+  #zergling: 16
+  #handler: 5
+__galaxy_systemd_memory_limit_merged: "{{ __galaxy_systemd_memory_limit | combine(galaxy_systemd_memory_limit | default({})) }}"
+
+# A list of KEY=val strings to be added as `Environment=KEY=val` to the systemd service unit
+galaxy_systemd_env: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -121,21 +121,12 @@
   tags:
     - galaxy_manage_errordocs
 
-#- name: Include systemd unit setup tasks (Zerg Mode)
-  #include_tasks:
-    #file: systemd-zerg.yml
-    #apply:
-      #tags: galaxy_manage_systemd
-  #when: galaxy_manage_systemd and galaxy_systemd.mode == "zerg"
-  #tags:
-    #- galaxy_manage_systemd
-
 - name: Include systemd unit setup tasks (Mules)
   include_tasks:
     file: systemd-mule.yml
     apply:
       tags: galaxy_manage_systemd
-  when: galaxy_manage_systemd and galaxy_systemd.mode == "mule"
+  when: galaxy_manage_systemd and galaxy_systemd_mode == "mule"
   tags:
     - galaxy_manage_systemd
 

--- a/templates/systemd/galaxy-reports.service.j2
+++ b/templates/systemd/galaxy-reports.service.j2
@@ -10,9 +10,12 @@ User={{ __galaxy_user_name }}
 Group={{ __galaxy_user_group }}
 WorkingDirectory={{ galaxy_server_dir }}
 TimeoutStartSec=10
-ExecStart={{ galaxy_venv_dir }}/bin/uwsgi {{ '--yaml' if galaxy_config_style in ('yaml', 'yml') else '--ini' }} {{ galaxy_reports_path }} --stats 127.0.0.1:4030
-Environment=HOME={{ galaxy_root }} VIRTUAL_ENV={{ galaxy_venv_dir }} PATH={{ galaxy_venv_dir }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin DOCUTILSCONFIG= PYTHONPATH={{ galaxy_dynamic_job_rules_dir }} {{ galaxy_systemd.env }}
-MemoryLimit={{ galaxy_systemd.memory_limit.reports }}G
+ExecStart={{ galaxy_venv_dir }}/bin/uwsgi {{ '--yaml' if galaxy_config_style in ('yaml', 'yml') else '--ini' }} {{ galaxy_reports_path }}
+Environment=HOME={{ galaxy_root }}
+Environment=VIRTUAL_ENV={{ galaxy_venv_dir }}
+Environment=PATH={{ galaxy_venv_dir }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin
+Environment=DOCUTILSCONFIG=
+MemoryLimit={{ __galaxy_systemd_memory_limit_merged.reports }}G
 Restart=always
 
 MemoryAccounting=yes

--- a/templates/systemd/galaxy.service.j2
+++ b/templates/systemd/galaxy.service.j2
@@ -10,10 +10,17 @@ User={{ __galaxy_user_name }}
 Group={{ __galaxy_user_group }}
 WorkingDirectory={{ galaxy_server_dir }}
 TimeoutStartSec=10
-ExecStart={{ galaxy_venv_dir }}/bin/uwsgi {{ '--yaml' if galaxy_config_style in ('yaml', 'yml') else '--ini' }} {{ galaxy_config_file }} {% if galaxy_systemd.stats %}--stats 127.0.0.1:{{ galaxy_systemd.stats }}{% endif %}
+ExecStart={{ galaxy_venv_dir }}/bin/uwsgi {{ '--yaml' if galaxy_config_style in ('yaml', 'yml') else '--ini' }} {{ galaxy_config_file }}
 
-Environment=HOME={{ galaxy_root }} VIRTUAL_ENV={{ galaxy_venv_dir }} PATH={{ galaxy_venv_dir }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin DOCUTILSCONFIG= PYTHONPATH={{ galaxy_dynamic_job_rules_dir }} {{ galaxy_systemd.env }}
-MemoryLimit={{ galaxy_systemd.memory_limit.mule }}G
+Environment=HOME={{ galaxy_root }}
+Environment=VIRTUAL_ENV={{ galaxy_venv_dir }}
+Environment=PATH={{ galaxy_venv_dir }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin
+Environment=DOCUTILSCONFIG=
+Environment=PYTHONPATH={{ galaxy_dynamic_job_rules_dir }}
+{% for env in galaxy_systemd_env %}
+Environment={{ env }}
+{% endfor %}
+MemoryLimit={{ __galaxy_systemd_memory_limit_merged.mule }}G
 Restart=always
 
 MemoryAccounting=yes


### PR DESCRIPTION
I also dropped the uWSGI stats port stuff - you can just set `stats: :port` in the `uwsgi` section of `galaxy.yml` to enable it if you want, and I didn't want to add more uWSGI-specific stuff to the role when we're deprecating uWSGI anyway.