### PR TITLE
Enable optional dynamic job rules as templates

### DIFF
--- a/tasks/static_setup.yml
+++ b/tasks/static_setup.yml
@@ -62,6 +62,14 @@
         src: "{{ galaxy_dynamic_job_rules_src_dir }}/{{ item }}"
         dest: "{{ galaxy_dynamic_job_rules_dir }}/{{ item }}"
       with_items: "{{ galaxy_dynamic_job_rules }}"
+      when: item.endswith(".py")
+
+    - name: Install dynamic job rules (template based)
+      template:
+        src: "{{ galaxy_dynamic_job_rules_src_dir }}/{{ item }}"
+        dest: "{{ galaxy_dynamic_job_rules_dir }}/{{ item | regex_replace('.j2$') }}"
+      with_items: "{{ galaxy_dynamic_job_rules }}"
+      when: item.endswith(".py.j2")
 
     - name: Ensure dynamic rule __init__.py's exist
       copy:

--- a/tasks/static_setup.yml
+++ b/tasks/static_setup.yml
@@ -57,14 +57,14 @@
         label: "{{ galaxy_dynamic_job_rules_dir }}/{{ item | dirname }}"
       with_items: "{{ galaxy_dynamic_job_rules }}"
 
-    - name: Install dynamic job rules
+    - name: Install dynamic job rules (static)
       copy:
         src: "{{ galaxy_dynamic_job_rules_src_dir }}/{{ item }}"
         dest: "{{ galaxy_dynamic_job_rules_dir }}/{{ item }}"
       with_items: "{{ galaxy_dynamic_job_rules }}"
       when: item.endswith(".py")
 
-    - name: Install dynamic job rules (template based)
+    - name: Install dynamic job rules (template)
       template:
         src: "{{ galaxy_dynamic_job_rules_src_dir }}/{{ item }}"
         dest: "{{ galaxy_dynamic_job_rules_dir }}/{{ item | regex_replace('.j2$') }}"


### PR DESCRIPTION
This PR enables the use of dynamic job rules as ansible templates, distinguishing from pure python setups.