### PR TITLE
Pin setuptools

### DIFF
--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -25,10 +25,9 @@
     PYTHONPATH: null
     VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
 
-- name: Ensure setuptools is latest working release (57.5.0)
+- name: Ensure setuptools is latest working release (<58)
   pip:
-    name: setuptools
-    version: 57.5.0
+    name: setuptools<58
     state: present
     extra_args: "{{ pip_extra_args | default('') }}"
     virtualenv: "{{ galaxy_venv_dir }}"

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -16,10 +16,20 @@
 
 - name: Ensure pip and setuptools are the latest release
   pip:
-    name: 
-      - pip
-      - setuptools
+    name: pip
     state: latest
+    extra_args: "{{ pip_extra_args | default('') }}"
+    virtualenv: "{{ galaxy_venv_dir }}"
+    virtualenv_command: "{{ galaxy_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
+  environment:
+    PYTHONPATH: null
+    VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+
+- name: Ensure setuptools is latest working release (57.5.0)
+  pip:
+    name: setuptools
+    version: 57.5.0
+    state: present
     extra_args: "{{ pip_extra_args | default('') }}"
     virtualenv: "{{ galaxy_venv_dir }}"
     virtualenv_command: "{{ galaxy_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"


### PR DESCRIPTION
At least in the k8s image building process, the newest setuptools is problematic due to them having dropped `use_2to3`.

`
error in attmap setup command: use_2to3 is invalid.
...
Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\nERROR: Could not find a version that satisfies the requirement attmap==0.12.11 (from versions: 0.1, 0.1.1, 0.1.2, 0.1.4, 0.1.5, 0.1.6, 0.1.7, 0.1.8, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5, 0.12.6, 0.12.7, 0.12.8, 0.12.9, 0.12.10, 0.12.11, 0.13.0)\nERROR: No matching distribution found for attmap==0.12.11\n"}
`

Pinning it seems to fix the problem.