### PR TITLE
Support updating Node when the pinned version changes

### DIFF
--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -61,6 +61,12 @@
           changed_when: false
           register: __galaxy_installed_node_version
 
+        - name: Remove node_modules directory when upgrading node
+          file:
+            path: "{{ galaxy_venv_dir }}/lib/node_modules"
+            state: absent
+          when: (not __galaxy_node_is_installed.stat.exists) or (('v' ~ galaxy_node_version) != __galaxy_installed_node_version.stdout)
+
         - name: Install or upgrade node
           command: "nodeenv -n {{ galaxy_node_version }} -p"
           environment:

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -50,13 +50,23 @@
           include_tasks: _inc_node_version.yml
           when: galaxy_node_version is undefined
 
-        - name: Install node
+        - name: Check if node is installed
+          stat:
+            path: "{{ galaxy_venv_dir }}/bin/node"
+          register: __galaxy_node_is_installed
+
+        - name: Collect installed node version
+          command: "{{ galaxy_venv_dir }}/bin/node --version"
+          when: __galaxy_node_is_installed.stat.exists
+          changed_when: false
+          register: __galaxy_installed_node_version
+
+        - name: Install or upgrade node
           command: "nodeenv -n {{ galaxy_node_version }} -p"
           environment:
             PATH: "{{ galaxy_venv_dir }}/bin:{{ ansible_env.PATH }}"
             VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
-          args:
-            creates: "{{ galaxy_venv_dir }}/bin/npm"
+          when: (not __galaxy_node_is_installed.stat.exists) or (('v' ~ galaxy_node_version) != __galaxy_installed_node_version.stdout)
 
         - name: Install yarn
           npm:


### PR DESCRIPTION
I got this error from the subsequent yarn install (`npm install --global yarn`) step, however. Not sure if this is just me, but the error is pretty inscrutable for someone not deeply familiar with Node:

```
TypeError: Class extends value undefined is not a constructor or null
    at Object.<anonymous> (/srv/galaxy/venv/lib/node_modules/npm/node_modules/socks-proxy-agent/dist/agent.js:114:44)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/srv/galaxy/venv/lib/node_modules/npm/node_modules/socks-proxy-agent/dist/index.js:5:33)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/srv/galaxy/venv/lib/node_modules/npm/node_modules/make-fetch-happen/lib/agent.js:161:25)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
```