### PR TITLE
Fix handler errors when systemd reload without become

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,15 +15,18 @@
   when: galaxy_admin_email_to is defined
 
 - name: daemon reload
+  become: true
   systemd:
     daemon_reload: yes
 
 - name: galaxy mule start
+  become: true
   systemd:
       name: galaxy.service
       state: started
 
 - name: galaxy mule restart
+  become: true
   systemd:
       name: galaxy.service
       state: restarted


### PR DESCRIPTION
This resolves an issue where these specific handlers are called from systemd-mule.yml and can't be overwritten with a custom galaxy restart handler. This would resolve my deployment issue. Better would be if the custom galaxy restart can be called from the systemd-mule.yml or systemd-reports.yml.