### PR TITLE
variable `galaxy_additional_venv_packages` to install extra python packages in galaxy venv

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -311,3 +311,6 @@ __galaxy_systemd_memory_limit_merged: "{{ __galaxy_systemd_memory_limit | combin
 
 # A list of KEY=val strings to be added as `Environment=KEY=val` to the systemd service unit
 galaxy_systemd_env: []
+
+# A list of additional python packages to install into galaxy's virtual environment
+galaxy_additional_venv_packages: []

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -44,7 +44,7 @@
       environment:
         PYTHONPATH: null
         VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
-      when: galaxy_additional_venv_packages is not []
+      when: galaxy_additional_venv_packages
 
   remote_user: "{{ galaxy_remote_users.privsep | default(__galaxy_remote_user) }}"
   become: "{{ true if galaxy_become_users.privsep is defined else __galaxy_become }}"

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -44,6 +44,7 @@
       environment:
         PYTHONPATH: null
         VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+      when: galaxy_additional_venv_packages is not []
 
   remote_user: "{{ galaxy_remote_users.privsep | default(__galaxy_remote_user) }}"
   become: "{{ true if galaxy_become_users.privsep is defined else __galaxy_become }}"

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -36,6 +36,15 @@
         VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
       when: (not ansible_check_mode) and conditional_dependencies.stdout_lines | length > 0
 
+    - name: Install additional packages into galaxy's virtual environment
+      pip:
+        name: "{{ galaxy_additional_venv_packages }}"
+        virtualenv: "{{ galaxy_venv_dir }}"
+        virtualenv_command: "{{ galaxy_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
+      environment:
+        PYTHONPATH: null
+        VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+
   remote_user: "{{ galaxy_remote_users.privsep | default(__galaxy_remote_user) }}"
   become: "{{ true if galaxy_become_users.privsep is defined else __galaxy_become }}"
   become_user: "{{ galaxy_become_users.privsep | default(__galaxy_become_user) }}"


### PR DESCRIPTION
For issue https://github.com/galaxyproject/ansible-galaxy/issues/140

The use case for Galaxy Australia is needing to install the `total-perspective-vortex` package into the venv after it has been created but before the restart handler runs.
