### PR TITLE
[WIP] Add a task to specify the brand color?

### DIFF
--- a/tasks/_inc_client_build_make.yml
+++ b/tasks/_inc_client_build_make.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Set brand color
+  shell: sed -i -e 's/^\$brand-primary.*$/\$brand-primary={{ brand_primary }}/' {{ galaxy_server_dir }}/client/src/style/scss/theme/blue.scss
+  when: brand_primary is defined
+
 - name: Build client
   make:
     chdir: "{{ galaxy_server_dir }}"


### PR DESCRIPTION
This PR attempts to add an option to specify the brand color in the playbook vars. Suggestions on improving this are very welcome, particularly the fixed path to the css theme file seems to be questionable. Also wondering if and how tests could be added. It might make sense to integrate this as Galaxy config option instead. Thanks in advance.