### PR TITLE
Install latest setuptools

### DIFF
--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -16,19 +16,10 @@
 
 - name: Ensure pip is the desired release
   pip:
-    name: pip
+    name:
+      - pip
+      - setuptools
     state: "{{ galaxy_pip_version | default('latest') }}"
-    extra_args: "{{ pip_extra_args | default('') }}"
-    virtualenv: "{{ galaxy_venv_dir }}"
-    virtualenv_command: "{{ galaxy_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
-  environment:
-    PYTHONPATH: null
-    VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
-
-- name: Ensure setuptools is latest working release (<58)
-  pip:
-    name: setuptools<58
-    state: present
     extra_args: "{{ pip_extra_args | default('') }}"
     virtualenv: "{{ galaxy_venv_dir }}"
     virtualenv_command: "{{ galaxy_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"


### PR DESCRIPTION
The dependencies that relied on `use_2to3` have been updated [1] and the changes in #139 are no longer necessary.

1. https://attmap.databio.org/en/latest/changelog/