### PR TITLE
Drop modifying venv activate to set `$GRAVITY_STATE_DIR`

### DIFF
--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -46,15 +46,6 @@
         VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
       when: galaxy_additional_venv_packages
 
-    - name: Configure $GRAVITY_STATE_DIR in virtualenv activate
-      blockinfile:
-        path: "{{ galaxy_venv_dir }}/bin/activate"
-        marker: "# {mark} GALAXYPROJECT.GALAXY ROLE ANSIBLE MANAGED BLOCK"
-        block: |
-          # Galaxy Gravity per-instance state directory configured by galaxyproject.galaxy Ansible role
-          GRAVITY_STATE_DIR={{ galaxy_gravity_state_dir | quote }}
-          export GRAVITY_STATE_DIR
-
   remote_user: "{{ galaxy_remote_users.privsep | default(__galaxy_remote_user) }}"
   become: "{{ true if galaxy_become_users.privsep is defined else __galaxy_become }}"
   become_user: "{{ galaxy_become_users.privsep | default(__galaxy_become_user) }}"


### PR DESCRIPTION
This was only ever done as a convenience and is no longer needed or desirable with Gravity 1.0 (keeping it generally won't harm anything either, although it might cause confusion down the line).