### PR TITLE
Second attempt at fixing, must be privsep to create

### DIFF
--- a/tasks/mutable_setup.yml
+++ b/tasks/mutable_setup.yml
@@ -1,20 +1,27 @@
 ---
 # Instantiate mutable config files
 
+- name: Mutable config directory setup
+  block:
+    - name: Create directories for mutable config files
+      ansible.builtin.file:
+        state: directory
+        path: "{{ item }}"
+        mode: "{{ __galaxy_dir_perms }}"
+        owner: "{{ __galaxy_user_name }}"
+        group: "{{ __galaxy_user_group }}"
+      loop: "{{ (galaxy_mutable_config_files + galaxy_mutable_config_templates) | map(attribute='dest') | map('dirname') | unique }}"
+
+  remote_user: "{{ galaxy_remote_users.privsep | default(__galaxy_remote_user) }}"
+  become: "{{ true if galaxy_become_users.privsep is defined else __galaxy_become }}"
+  become_user: "{{ galaxy_become_users.privsep | default(__galaxy_become_user) }}"
+
 - name: Mutable config setup
   block:
 
     - name: Ensure Galaxy version is set
       include_tasks: _inc_galaxy_version.yml
       when: __galaxy_major_version is undefined
-
-    - name: Create directories for config files
-      ansible.builtin.file:
-        state: directory
-        path: "{{ item }}"
-        mode: "{{ __galaxy_dir_perms }}"
-        group: "{{ __galaxy_user_group }}"
-      loop: "{{ (galaxy_mutable_config_files + galaxy_mutable_config_templates) | map(attribute='dest') | map('dirname') | unique }}"
 
     # force: no in the following 2 tasks will not overwrite existing configs
     - name: Instantiate mutable configuration files


### PR DESCRIPTION
Based on #188 and #189, mutable directories must be created by the privsep user, with galaxy_user:galaxy_group