### PR TITLE
Fix issue with jinja2 < 2.11.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -188,7 +188,7 @@ _galaxy_tmpclean_command:
 
 galaxy_tmpclean_verbose_statement: "{{ galaxy_tmpclean_verbose | ternary(' -v', '') }}"
 galaxy_tmpclean_log_statement: >-
-  {{ (galaxy_tmpclean_log is not true) | ternary(
+  {{ (galaxy_tmpclean_log != true) | ternary(
       ((galaxy_tmpclean_log is none) | ternary(
           '>/dev/null',
           '>>' ~ galaxy_tmpclean_log


### PR DESCRIPTION
Ubuntu 20.04 LTS has jinja2 2.10.1, which doesn't support `is true` and various other `is` tests added in https://github.com/pallets/jinja/pull/824

Fix:
```
TASK [galaxyproject.galaxy : Schedule tmpclean cron job (root)] *******************************************************************************************************************************************
fatal: [gat-18.eu.galaxy.training]: FAILED! => 
  msg: |-
    An unhandled exception occurred while templating '{{ (galaxy_tmpclean_log is not true) | ternary(
        ((galaxy_tmpclean_log is none) | ternary(
            '>/dev/null',
            '>>' ~ galaxy_tmpclean_log
        )),
        ''
    ) }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: template error while templating string: no test named 'true'. String: {{ (galaxy_tmpclean_log is not true) | ternary(
        ((galaxy_tmpclean_log is none) | ternary(
            '>/dev/null',
            '>>' ~ galaxy_tmpclean_log
        )),
        ''
    ) }}
```

when using ansible 2.12.10 .

Alternatively we could make clear that jinja >= 2.11.0 is required.