### PR TITLE
Symlinks reduce disk usage

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -512,6 +512,8 @@ galaxy_themes_static_keys:
 galaxy_themes_conf_path: files/galaxy/config/themes_conf.yml
 galaxy_themes_static_path: "{{ galaxy_root }}/server"
 galaxy_themes_static_dir: "{{ galaxy_root }}/server/static"
+galaxy_themes_symlinks: true
+galaxy_themes_no_symlinks_log: false # Hides extended logs for the symlink task in static/dist
 galaxy_themes_welcome_url_prefix: https://usegalaxy-eu.github.io/index-
 galaxy_themes_default_welcome: https://galaxyproject.org
 galaxy_themes_ansible_file_path: files/galaxy/static

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -513,7 +513,7 @@ galaxy_themes_conf_path: files/galaxy/config/themes_conf.yml
 galaxy_themes_static_path: "{{ galaxy_root }}/server"
 galaxy_themes_static_dir: "{{ galaxy_root }}/server/static"
 galaxy_themes_symlinks: true
-galaxy_themes_no_symlinks_log: false # Hides extended logs for the symlink task in static/dist
+galaxy_themes_symlinks_no_log: false # Hides extended logs for the symlink task in static/dist
 galaxy_themes_welcome_url_prefix: https://usegalaxy-eu.github.io/index-
 galaxy_themes_default_welcome: https://galaxyproject.org
 galaxy_themes_ansible_file_path: files/galaxy/static

--- a/tasks/static_subdomain_dirs.yml
+++ b/tasks/static_subdomain_dirs.yml
@@ -5,7 +5,40 @@
     mode: '0755'
     owner: "{{ __galaxy_privsep_user_name }}"
     group: "{{ __galaxy_privsep_user_group }}"
-    path: "{{ galaxy_themes_static_path }}/static-{{ subdomain.name }}"
+    path: "{{ galaxy_themes_static_path }}/{{ item }}"
+  with_items:
+    - "static-{{ subdomain.name }}"
+    - "static-{{ subdomain.name }}/dist"
+
+- name: Register files in static/dist
+  ansible.builtin.find:
+    paths: "{{ galaxy_themes_static_path }}/static/dist"
+    file_type: file
+  when: galaxy_themes_symlinks
+  register: dist_files
+
+- name: "Symlink files static-{{ subdomain.name }}/dist to static/dist"
+  ansible.builtin.file:
+    src: "{{ item.path }}"
+    dest: "{{ galaxy_themes_static_path }}/static-{{ subdomain.name }}/dist/{{ item.path | basename }}"
+    state: link
+  when: galaxy_themes_symlinks
+  no_log: "{{ galaxy_themes_no_symlinks_log }}"
+  with_items: "{{ dist_files.files }}"
+
+- name: "Symlink directory {{ item }} from static-{{ subdomain.name }}/{{ item }} to static/{{ item }}"
+  ansible.builtin.file:
+    src: "{{ galaxy_themes_static_path }}/static/{{ item }}"
+    dest: "{{ galaxy_themes_static_path }}/static-{{ subdomain.name }}/{{ item }}"
+    state: link
+  when: galaxy_themes_symlinks
+  ignore_errors: true
+  with_items:
+    - "plugins"
+    - "patmat"
+    - "toolshed"
+    - "wymeditor"
+    - "style"
 
 - name: Synchronize contents from static to static-"{{ subdomain.name }}"
   ansible.posix.synchronize:

--- a/tasks/static_subdomain_dirs.yml
+++ b/tasks/static_subdomain_dirs.yml
@@ -23,7 +23,7 @@
     dest: "{{ galaxy_themes_static_path }}/static-{{ subdomain.name }}/dist/{{ item.path | basename }}"
     state: link
   when: galaxy_themes_symlinks
-  no_log: "{{ galaxy_themes_no_symlinks_log }}"
+  no_log: "{{ galaxy_themes_symlinks_no_log }}"
   with_items: "{{ dist_files.files }}"
 
 - name: "Symlink directory {{ item }} from static-{{ subdomain.name }}/{{ item }} to static/{{ item }}"


### PR DESCRIPTION
This is a small improvement for the copy tasks in the static directories
As the role currently works, the whole static directory is `rsync`ed into every new subdomain directory, which leads to additional disk usage of ~ 154 MB for each subdomain in a basic (GTN) Galaxy setup.

With this improvement, several static subdirectories are symlinked and all files inside `dist` are symlinked, which reduces the disk usage per subdomain to ~ 2.3 MB.

However the disadvantage of this is:
- more extensive logs; each symlink needs to be checked and is logged by ansible, around 200 per subdomain, the `galaxy_themes_no_symlink_logs` just reduces the extent, but ansible still prints one line per file and subdomain
- slightly slower playbook runs; `synchronize` for the whole folder is faster than invoking an ansible operation for each file and we don't get rid of the `synchronize` fully, because we would need to create multiple subdirectories manually and iterate over them with symlink tasks

To solve this conflict, I added variables that let the user decide weather to use the symlink feature and reduce the logs or not