### PR TITLE
Support installing local tools into sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,9 @@ Options for configuring Galaxy and controlling which version is installed.
 - `galaxy_config_files`: List of hashes (with `src` and `dest` keys) of files to copy from the control machine. For example, to set job destinations, you can use the `galaxy_config_dir` variable followed by the file name as the `dest`, e.g. `dest: "{{ galaxy_config_dir }}/job_conf.xml"`. Make sure to add the appropriate setup within `galaxy_config` for each file added here (so, if adding `job_conf.xml` make sure that `galaxy_config.galaxy.job_config_file` points to that file).
 - `galaxy_config_templates`: List of hashes (with `src` and `dest` keys) of templates to fill from the control machine.
 - `galaxy_local_tools`: List of local tool files or directories to copy from the control machine, relative to
-  `galaxy_local_tools_src_dir` (default: `files/galaxy/tools` in the playbook).
+  `galaxy_local_tools_src_dir` (default: `files/galaxy/tools` in the playbook). List items can either be a tool
+  filename, or a dictionary with keys `file`, `section_name`, and, optionally, `section_id`. If no `section_name` is
+  specified, tools will be placed in a section named **Local Tools**.
 - `galaxy_local_tools_dir`: Directory on the Galaxy server where local tools will be installed.
 - `galaxy_dynamic_job_rules`: List of dynamic job rules to copy from the control machine, relative to
   `galaxy_dynamic_job_rules_src_dir` (default: `files/galaxy/dynamic_job_rules` in the playbook).

--- a/tasks/static_setup.yml
+++ b/tasks/static_setup.yml
@@ -43,10 +43,10 @@
 
     - name: Install local tools
       copy:
-        src: "{{ galaxy_local_tools_src_dir }}/{{ item }}"
-        dest: "{{ galaxy_local_tools_dir }}/{{ item }}"
+        src: "{{ galaxy_local_tools_src_dir }}/{{ item.file | default(item) }}"
+        dest: "{{ galaxy_local_tools_dir }}/{{ item.file | default(item) }}"
         mode: preserve
-      with_items: "{{ galaxy_local_tools | default([]) }}"
+      loop: "{{ galaxy_local_tools | default([]) }}"
       when: galaxy_local_tools is defined
 
     - name: Install local_tool_conf.xml

--- a/templates/local_tool_conf.xml.j2
+++ b/templates/local_tool_conf.xml.j2
@@ -1,8 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
 <toolbox monitor="true" tool_path="{{ galaxy_local_tools_dir }}">
 {% for tool in galaxy_local_tools %}
-{% if tool.endswith('.xml') %}
-    <tool file="{{ tool }}" />
+{% if tool is not mapping %}
+{% set tool = {'section_name': 'Local Tools', 'file': tool} %}
+{% endif %}
+{% if tool.file.endswith('.xml') %}
+    <section id="{{ tool.section_id | default(tool.section_name | regex_replace('[^A-Za-z0-9]', '_') | lower) }}" name="{{ tool.section_name }}">
+        <tool file="{{ tool.file }}" />
+    </section>
 {% endif %}
 {% endfor %}
 </toolbox>


### PR DESCRIPTION
This alters the previous behavior slightly, tools that do not specify a section will be placed in a section named **Local Tools** whereas previously they would be outside of a section.

The old simple syntax is still supported:

```yaml
galaxy_local_tools:
  - foo.xml
  - bar.xml
```

Is the same as:

```yaml
galaxy_local_tools:
  - file: foo.xml
    section_name: Local Tools
  - file: bar.xml
    section_name: Local Tools
```