### PR TITLE
Add GRAVITY_CONFIG_FILE to systemd env

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -19,6 +19,7 @@
     galaxy_user: galaxy
     galaxy_group: galaxy
     galaxy_privsep_user: gxpriv
+    galaxy_clone_depth: 1
     galaxy_config:
       galaxy:
         database_connection: sqlite:///{{ galaxy_mutable_data_dir }}/universe.sqlite
@@ -61,6 +62,7 @@
     - name: Collect current commit id
       git:
         clone: false
+        depth: "{{ galaxy_clone_depth }}"
         dest: "{{ galaxy_root }}/server"
         repo: https://github.com/galaxyproject/galaxy.git
       changed_when: false

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -39,7 +39,18 @@
       when: ansible_os_family == "RedHat" and ansible_distribution_major_version is version("8", ">=")
     - name: Install dependencies (apt)
       apt:
-        name: [sudo, git, make, python3-venv, python3-setuptools]
+        name:
+          - sudo
+          - git
+          - make
+          - python3-venv
+          - python3-setuptools
+          - python3-dev
+          - python3-psycopg2
+          - gcc
+          - acl
+          - gnutls-bin
+          - libmagic-dev
       when: ansible_os_family == "Debian"
 
     # This is to cheat at idempotence, which will fail if a commit is merged between converge and idempotence.

--- a/templates/systemd/galaxy.service.j2
+++ b/templates/systemd/galaxy.service.j2
@@ -25,6 +25,7 @@ Environment=PATH={{ galaxy_venv_dir }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/loc
 Environment=DOCUTILSCONFIG=
 Environment=PYTHONPATH={{ galaxy_dynamic_job_rules_dir }}
 Environment=GRAVITY_STATE_DIR={{ galaxy_gravity_state_dir }}
+Environment=GRAVITY_CONFIG_FILE={{ galaxy_config_file }}
 {% for env in galaxy_systemd_env %}
 Environment={{ env }}
 {% endfor %}


### PR DESCRIPTION
I noticed the reason why the molecule runs for version `23.0` were failing was that `supervisord` was attempting to run Galaxy with the wrong config file. On the failing containers, `/srv/galaxy/var/gravity/supervisor/supervisord.conf.d/_default_.d/galaxy_gunicorn_gunicorn.conf` has:

```
command         = /srv/galaxy/venv/bin/galaxyctl --config-file /srv/galaxy/server/config/galaxy.yml.sample exec _default_ gunicorn
```

It looks like this is because the systemd unit file doesn't correctly set the `GRAVITY_CONFIG_FILE` environment variable.

Additionally, I locally ran into some issues requiring further `apt` dependencies to be installed on Ubuntu in order for some of Galaxy's dependencies to compile correctly. This does not seem to have lead to test failures on CI, my hunch is that this due to me using an `ARM` based machine locally, but I'm not sure. I've added the extra `apt` dependencies that I needed as they seem pretty sane, but feel free to chuck out that commit, of course :)