### PR TITLE
disable galaxy config sorting

### DIFF
--- a/templates/galaxy.yml.j2
+++ b/templates/galaxy.yml.j2
@@ -23,9 +23,9 @@
 
 {#- add any other defined sections -#}
 {% for section, val in galaxy_config | dictsort if section not in ('uwsgi', 'gravity', galaxy_app_config_section) %}
-{{ {section: val} | to_nice_yaml(indent=4) }}
+{{ {section: val} | to_nice_yaml(indent=4, sort_keys=false) }}
 {% endfor %}
 {% for key, value in galaxy_config_merged[galaxy_app_config_section] | dictsort %}
 {% set _dummy=galaxy_config_merged[galaxy_app_config_section].pop(key) if value is mapping and value|length == 0  %}
 {% endfor %}
-{{ {galaxy_app_config_section: galaxy_config_merged[galaxy_app_config_section]} | to_nice_yaml(indent=4) }}
+{{ {galaxy_app_config_section: galaxy_config_merged[galaxy_app_config_section]} | to_nice_yaml(indent=4, sort_keys=false) }}


### PR DESCRIPTION
In EU @bgruening observed that the [brand_by_host](https://github.com/usegalaxy-eu/infrastructure-playbook/blob/master/group_vars/gxconfig.yml#L1048) gets sorted in the final configuration when written to disk (`galaxy.yml` file). As a result of this sorting, the [usegalaxy.eu: Europe](https://github.com/usegalaxy-eu/infrastructure-playbook/blob/master/group_vars/gxconfig.yml#L1049) comes before the subdomain [virology.usegalaxy.eu: Virology](https://github.com/usegalaxy-eu/infrastructure-playbook/blob/master/group_vars/gxconfig.yml#L1075), which leads to the misbranding of the subdomain https://virology.usegalaxy.eu. This subdomain contains the brand `Europe` instead of `Virology`.

Example (final config from `galaxy.yml`):

```YAML
    brand_by_host:
        africa.usegalaxy.eu: Africa
        annotation.usegalaxy.eu: Genome Annotation
        ...
        ...
        ...
        usegalaxy.eu: Europe
        virology.usegalaxy.eu: Virology
```

By default, `sort_keys` is set to `true` in the `to_nice_yaml` function in the `galaxy.yml.j2` template. Sorting the `brand_by_host` in Galaxy config affects the branding of the subdomains. Therefore, this PR disables the default `sort_keys.`

@natefoo, I am unsure whether the default sorting is needed for anything in Galaxy configuration. Please correct me if this is not the case. 