### PR TITLE
Make themes structured data instead of read from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,60 +95,63 @@ Options below that control individual file or subdirectory placement can still o
 [custom]: vars/layout-custom.yml
 [fhs]: http://www.pathname.com/fhs/
 
-**New options for Galaxy 22.01 and later**
+**Process control with Gravity**
 
-The role can now manage the Galaxy service using [gravity][gravity]. This is the default for Galaxy 22.05 and later.
+The role can manage the Galaxy service using [gravity][gravity]. This is the default for Galaxy 22.05 and later.
 Additionally, support for the `galaxy_restart_handler_name` variable has been removed. If you need to enable your own
-custom restart handler, you can use the "`listen`" option to the handler as explained in the
-[handler documentation](https://docs.ansible.com/ansible/latest/user_guide/playbooks_handlers.html#using-variables-with-handlers).
+custom restart handler, you can use the "`listen`" option to the handler as explained in the [handler
+documentation](https://docs.ansible.com/ansible/latest/user_guide/playbooks_handlers.html#using-variables-with-handlers).
 The handler should "listen" to the topic `"restart galaxy"`.
 
 [gravity]: https://github.com/galaxyproject/gravity
 
-From release 22.01 Galaxy can serve different static content per host (e.g. subdomain) and you can set [themes][themes] per host.
+**Galaxy Themes**
 
-By setting `galaxy_manage_subdomain_static: yes` you enable the creation of static directories and configuration per host and by setting `galaxy_manage_themes: yes` the role will append your themes_config.yml file specified under `galaxy_themes_conf_path` to your themes files after coping them over to your galaxy server and create the respective configuration.
+From release 22.01, Galaxy users can select between different UI [themes][themes]. You can define themes using the
+`galaxy_themes` variable, the syntax of which is the same as the `themes_conf.yml` file described [in the themes
+training][themes].
+
+The `galaxy_manage_themes` variable controls whether the role manages theme configs and is automatically enabled if
+`galaxy_themes` is defined. If you just want to load the the sample themes from Galaxy's
+[themes_conf.yml.sample][themes_conf_sample] without defining your own, you can manually set `galaxy_manage_themes` to
+`true`.
+
+[themes]: https://training.galaxyproject.org/training-material/topics/admin/tutorials/customization/tutorial.html
+[themes_conf_sample]: https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/config/sample/themes_conf.yml.sample
+
+**Galaxy Subdomains**
+
+From release 22.01 Galaxy can serve different static content and themes per host (e.g. subdomain).
+
+By setting `galaxy_manage_subdomain_static: yes` you enable the creation of static directories and configuration per host.
 
 In order to use this feature, you need to create the following directory structure under files/ (customizable with the `galaxy_themes_ansible_file_path` variable):
 
 ~~~bash
 files/galaxy/static
 ├──<subdomain-name-1>
-│   ├── static
-│   │   ├── dist (optional)
-│   │   │   └── some-image.png 
-│   │   ├── images (optional)
-│   │   │   └── more-content.jpg
-│   │   └── welcome.html (optional, galaxyproject.org will be displayed otherwise.)
-│   └── themes 
-│       └── <subdomain-name-1>.yml           
+│   └── static
+│       ├── dist (optional)
+│       │   └── some-image.png
+│       ├── images (optional)
+│       │   └── more-content.jpg
+│       └── welcome.html (optional, galaxyproject.org will be displayed otherwise.)
 ├── <subdomain-name-2>                            
-│   ├── static
-│   │   ├── dist (optional)
-│   │   │   ├── another-static-image.svg
-│   │   │   └── more-static-content-2.svg
-│   │   └── welcome.html (optional)
-│   └── themes
-│       └── <subdomain-name-2>.yml
+│   └── static
+│       ├── dist (optional)
+│       │   ├── another-static-image.svg
+│       │   └── more-static-content-2.svg
+│       └── welcome.html (optional)
 ... (and many more subdomains)
 ~~~
 
-Where the <subdomain-name-1> should exactly match your subdomain's name. The subdirectories `static` and `themes` are mandatory, as well as the correctly named theme file (if you enabled `galaxy_manage_themes`), while all subdirectories in `static` are optional.  
-Which subdirectories and files are copied is managed by the `static_galaxy_themes_keys` variable.
+Where the <subdomain-name-1> should exactly match your subdomain's name. The subdirectory `static` is mandatory, while all subdirectories in `static` are optional. Which subdirectories and files are copied is managed by the `static_galaxy_themes_keys` variable.
 
 Also make sure that you set `galaxy_themes_welcome_url_prefix`, so your welcome pages are templated correctly.
 
 It is mandatory to set the variables under `galaxy_themes_subdomains` as shown in the example in [defaults/main.yml](defaults/main.yml). If you enabled the `galaxy_manage_host_filters` variable, you can also specify the tool sections that should be shown for each individual subdomain.
 
-
-
-[themes]: https://training.galaxyproject.org/training-material/topics/admin/tutorials/customization/tutorial.html
-**New options for Galaxy 18.01 and later**
-
-- `galaxy_config_style` (default: `yaml`): The type of Galaxy configuration file to write, `yaml` for the YAML format supported by Gunicorn or `ini-paste` for the traditional PasteDeploy-style INI file
-- `galaxy_app_config_section` (default: depends on `galaxy_config_style`): The config file section under which the
-  Galaxy config should be placed (and the key in `galaxy_config` in which the Galaxy config can be found. If
-  `galaxy_config_style` is `yaml` the default is `galaxy`. If `galaxy_config_style` is `ini-paste`, the default is `app:main`.
+Each subdomain can be given its own theme, which is defined under the `theme` key of the subdomain's entry in `galaxy_themes_subdomains`. This theme will be the default for the subdomain, and any other themes defined globally for the server will also be available for the user to select. If a subdomain's `theme` is not defined, the global default is used. An example is provided in [defaults/main.yml](defaults/main.yml).
 
 **Feature control**
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -347,7 +347,7 @@ galaxy_app_config_default:
     { {% if galaxy_manage_themes %}
     '{{ galaxy_themes_instance_domain }}': '{{ galaxy_themes_conf_file_name }}',
     {% for subdomain in galaxy_themes_subdomains %}
-    '{{ subdomain.name  }}.{{ galaxy_themes_instance_domain}}': '{{ subdomain.name }}.yml',
+    '{{ subdomain.name  }}.{{ galaxy_themes_instance_domain}}': 'themes_conf-{{ subdomain.name }}.yml',
     {% endfor %}
     {% endif %} }
   brand_by_host: >

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,7 @@ galaxy_manage_gravity: "{{ false if __galaxy_major_version is version('22.05', '
 galaxy_manage_systemd: no # For Galaxy
 galaxy_manage_systemd_reports: no # For Reports
 galaxy_manage_cleanup: no
-galaxy_manage_themes: no
+galaxy_manage_themes: "{{ galaxy_manage_static_setup and (galaxy_themes is defined or galaxy_themes_subdomains) }}"
 galaxy_manage_subdomain_static: no
 galaxy_manage_host_filters: no
 galaxy_auto_brand: no # automatically sets the subdomain name as brand
@@ -271,6 +271,7 @@ galaxy_app_config_default:
   ucsc_build_sites: "{{ galaxy_server_dir }}/tool-data/shared/ucsc/ucsc_build_sites.txt.sample"
   tool_data_table_config_path: "{{ galaxy_server_dir }}/config/tool_data_table_conf.xml.sample"
   tool_sheds_config_file: "{{ galaxy_server_dir }}/config/tool_sheds_conf.xml.sample"
+  themes_config_file: "{{ galaxy_config_dir }}/themes_conf.yml"
 
   # Various cache and temporary directories
   data_dir: "{{ galaxy_mutable_data_dir }}"
@@ -344,10 +345,11 @@ galaxy_app_config_default:
     {% endfor %}
     {% endif %} }
   themes_config_file_by_host: >
-    { {% if galaxy_manage_themes %}
-    '{{ galaxy_themes_instance_domain }}': '{{ galaxy_themes_conf_file_name }}',
+    { {% if galaxy_manage_themes and galaxy_themes_subdomains %}
     {% for subdomain in galaxy_themes_subdomains %}
+    {% if subdomain.theme is defined %}
     '{{ subdomain.name  }}.{{ galaxy_themes_instance_domain}}': 'themes_conf-{{ subdomain.name }}.yml',
+    {% endif %}
     {% endfor %}
     {% endif %} }
   brand_by_host: >
@@ -511,7 +513,19 @@ galaxy_themes_subdomains: []
 #     - "multiple_alignments"
 #   extra_tool_labels:
 #     - "proteomics"
-galaxy_themes_conf_file_name: "{{ galaxy_themes_conf_path | basename }}"
+#   # default theme (optional)
+#   theme:
+#     assembly:
+#       masthead:
+#         color: >
+#           bottom -90px left / 1000px no-repeat url("/static/dist/flying-bird-1.svg"),
+#           bottom -90px left / 1000px no-repeat url("/static/dist/flying-bird-2.svg"),
+#           linear-gradient( 20deg,
+#             rgb(7, 40, 98) 0%,
+#             rgb(69, 122, 184) 48%,
+#             rgba(165, 204, 210, 0.9676562309265136) 74%,
+#             rgb(228, 195, 131) 92%,
+#             rgb(203, 119, 79) 100%)
 galaxy_themes_static_keys:
   static_dir: ""
   static_images_dir: "images/"
@@ -519,7 +533,6 @@ galaxy_themes_static_keys:
   static_welcome_html: "welcome.html/"
   static_favicon_dir: "favicon.ico"
   static_robots_txt: "robots.txt"
-galaxy_themes_conf_path: files/galaxy/config/themes_conf.yml
 galaxy_themes_static_path: "{{ galaxy_root }}/server"
 galaxy_themes_static_dir: "{{ galaxy_root }}/server/static"
 galaxy_themes_symlinks: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -346,6 +346,7 @@ galaxy_app_config_default:
     {% endif %} }
   themes_config_file_by_host: >
     { {% if galaxy_manage_themes and galaxy_themes_subdomains %}
+    '{{ galaxy_themes_instance_domain }}': '{{ galaxy_config.galaxy.themes_config_file | default((galaxy_config_dir, "themes_conf.yml") | path_join) }}',
     {% for subdomain in galaxy_themes_subdomains %}
     {% if subdomain.theme is defined %}
     '{{ subdomain.name  }}.{{ galaxy_themes_instance_domain}}': 'themes_conf-{{ subdomain.name }}.yml',

--- a/tasks/themes.yml
+++ b/tasks/themes.yml
@@ -19,7 +19,7 @@
     - name: Write base themes config
       ansible.builtin.copy:
         content: "{{ galaxy_themes | to_yaml }}"
-        dest: "{{ galaxy_config_merged.themes_config_file | default((galaxy_config_dir, 'themes_conf.yml') | path_join) }}"
+        dest: "{{ galaxy_config_merged.galaxy.themes_config_file | default((galaxy_config_dir, 'themes_conf.yml') | path_join) }}"
         mode: "0644"
 
     - name: Write subdomain themes configs

--- a/tasks/themes.yml
+++ b/tasks/themes.yml
@@ -16,7 +16,7 @@
           ansible.builtin.set_fact:
             galaxy_themes: "{{ __galaxy_themes_config_slurp.content | b64decode | from_yaml }}"
 
-    - name: Write default themes config
+    - name: Write base themes config
       ansible.builtin.copy:
         content: "{{ galaxy_themes | to_yaml }}"
         dest: "{{ galaxy_config_merged.themes_config_file | default((galaxy_config_dir, 'themes_conf.yml') | path_join) }}"
@@ -25,12 +25,11 @@
     - name: Write subdomain themes configs
       ansible.builtin.copy:
         content: |
-          {% if item.theme is defined %}
           {{ item.theme | to_yaml }}
-          {% endif %}
           {{ galaxy_themes | to_yaml }}
         dest: "{{ galaxy_config_dir }}/themes_conf-{{ item.name }}.yml"
         mode: "0644"
+      when: item.theme is defined
       loop: "{{ galaxy_themes_subdomains }}"
 
   remote_user: "{{ galaxy_remote_users.privsep | default(__galaxy_remote_user) }}"

--- a/tasks/themes.yml
+++ b/tasks/themes.yml
@@ -1,15 +1,38 @@
 ---
-- name: Append themes_conf.yml to all files in galaxy/config/themes
-  ansible.builtin.blockinfile:
-    block: "{{ lookup('ansible.builtin.file', galaxy_themes_conf_path) }}"
-    path: "{{ galaxy_themes_ansible_file_path }}/{{ subdomain.name }}/themes/{{ subdomain.name }}.yml"
-  delegate_to: 127.0.0.1
 
-- name: Copy themes files
-  ansible.builtin.copy:
-    src: "{{ galaxy_themes_ansible_file_path }}/{{ subdomain.name }}/themes/{{ subdomain.name }}.yml"
-    dest: "{{ galaxy_config_dir }}"
-    mode: '0644'
-    owner: "{{ __galaxy_privsep_user_name }}"
-    group: "{{ __galaxy_privsep_user_group }}"
+- name: Themes setup
+  block:
 
+    - name: Default themes block
+      when: galaxy_themes is not defined
+      block:
+
+        - name: Load default themes if unset
+          ansible.builtin.slurp:
+            src: "{{ (galaxy_server_dir, 'lib/galaxy/config/sample/themes_conf.yml.sample') | path_join }}"
+          register: __galaxy_themes_config_slurp
+
+        - name: Set galaxy_themes
+          ansible.builtin.set_fact:
+            galaxy_themes: "{{ __galaxy_themes_config_slurp.content | b64decode | from_yaml }}"
+
+    - name: Write default themes config
+      ansible.builtin.copy:
+        content: "{{ galaxy_themes | to_yaml }}"
+        dest: "{{ galaxy_config_merged.themes_config_file | default((galaxy_config_dir, 'themes_conf.yml') | path_join) }}"
+        mode: "0644"
+
+    - name: Write subdomain themes configs
+      ansible.builtin.copy:
+        content: |
+          {% if item.theme is defined %}
+          {{ item.theme | to_yaml }}
+          {% endif %}
+          {{ galaxy_themes | to_yaml }}
+        dest: "{{ galaxy_config_dir }}/themes_conf-{{ item.name }}.yml"
+        mode: "0644"
+      loop: "{{ galaxy_themes_subdomains }}"
+
+  remote_user: "{{ galaxy_remote_users.privsep | default(__galaxy_remote_user) }}"
+  become: "{{ true if galaxy_become_users.privsep is defined else __galaxy_become }}"
+  become_user: "{{ galaxy_become_users.privsep | default(__galaxy_become_user) }}"


### PR DESCRIPTION
This way the role does not modify files in the playbook, and moves in line with other recent changes to move more of Galaxy's extraneous configs into structured data.

@mira-miracoli if you approve I'll update the documentation.