### PR TITLE
Update welcome.html.j2 with additional check to ensure that subdomain variable is defined

### DIFF
--- a/templates/welcome.html.j2
+++ b/templates/welcome.html.j2
@@ -28,7 +28,7 @@
 		onload="this.style.position='static'; this.style.visibility='visible';"></iframe>
 	<script type="text/javascript">
 		var pseudo_rand = parseInt(Date.now() / 1000 / 60 / 10);
-		{% if galaxy_themes_use_iframe is defined | default(false) and subdomain %}
+		{% if galaxy_themes_use_iframe is defined and subdomain is defined %}
 		document.getElementById('center-iframe').src = '{{ galaxy_themes_welcome_url_prefix }}{{ subdomain.name }}?nonce=' + pseudo_rand + '#';
 		{% else %}
 		document.getElementById('center-iframe').src = '{{ galaxy_themes_default_welcome }}?nonce=' + pseudo_rand + '#';

--- a/templates/welcome.html.j2
+++ b/templates/welcome.html.j2
@@ -28,7 +28,7 @@
 		onload="this.style.position='static'; this.style.visibility='visible';"></iframe>
 	<script type="text/javascript">
 		var pseudo_rand = parseInt(Date.now() / 1000 / 60 / 10);
-		{% if galaxy_themes_use_iframe is defined and subdomain is defined %}
+		{% if galaxy_themes_use_iframe is defined and subdomain is defined and galaxy_themes_use_iframe.status == 200 %}
 		document.getElementById('center-iframe').src = '{{ galaxy_themes_welcome_url_prefix }}{{ subdomain.name }}?nonce=' + pseudo_rand + '#';
 		{% else %}
 		document.getElementById('center-iframe').src = '{{ galaxy_themes_default_welcome }}?nonce=' + pseudo_rand + '#';

--- a/templates/welcome.html.j2
+++ b/templates/welcome.html.j2
@@ -28,7 +28,7 @@
 		onload="this.style.position='static'; this.style.visibility='visible';"></iframe>
 	<script type="text/javascript">
 		var pseudo_rand = parseInt(Date.now() / 1000 / 60 / 10);
-		{% if galaxy_themes_use_iframe is defined %}
+		{% if galaxy_themes_use_iframe is defined | default(false) and subdomain %}
 		document.getElementById('center-iframe').src = '{{ galaxy_themes_welcome_url_prefix }}{{ subdomain.name }}?nonce=' + pseudo_rand + '#';
 		{% else %}
 		document.getElementById('center-iframe').src = '{{ galaxy_themes_default_welcome }}?nonce=' + pseudo_rand + '#';


### PR DESCRIPTION
During a fresh deployment, I find that not having the changes proposed in this PR leads to the following error,

```
2025-07-21 14:36:05,725 p=183333 u=sanjay n=ansible | TASK [galaxyproject.galaxy : Template welcome.html for basedomain] ***************************************************************************************************************************************************************************************************
2025-07-21 14:36:06,182 p=183333 u=sanjay n=ansible | An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'subdomain' is undefined. 'subdomain' is undefined
2025-07-21 14:36:06,183 p=183333 u=sanjay n=ansible | fatal: [sn09.galaxyproject.eu]: FAILED! => changed=false 
  msg: 'AnsibleUndefinedVariable: ''subdomain'' is undefined. ''subdomain'' is undefined'
```

I am not exactly sure of the precise origin of the issue — the `if` branch in the `welcome.html.j2` template should only run for subdomains, because the variable `galaxy_themes_use_iframe` is only set in the [subdomain `uri` task](https://github.com/galaxyproject/ansible-galaxy/blob/main/tasks/static_subdomain_dirs.yml#L69).
However, the error occurs when rendering `welcome.html` for the `basedomain` (task [here](https://github.com/galaxyproject/ansible-galaxy/blob/main/tasks/static_dirs.yml#L10)).

My best guess is that this is likely caused by the fact that the Jinja condition in the template only checks:

```jinja2
{% if galaxy_themes_use_iframe is defined %}
```

which does not consider whether it is *truthy*, only whether it is defined. Because Ansible facts persist across tasks in a play, it might be the case that `galaxy_themes_use_iframe` remains set from an earlier subdomain task run (e.g. as `true`), causing the template to enter the branch referencing `subdomain.name`, which does not exist in the basedomain context and thus raises the `UndefinedVariable` error.

_This might also be due to the variable being set in earlier runs or loops within the play, as Ansible facts are global to the host context unless explicitly unset._

So, to ensure smooth deployment this PR changes the condition in the template to avoid referencing an undefined subdomain variable:

_before:_

```jinja2
{% if galaxy_themes_use_iframe is defined %}
```

_after:_
```jinja2
{% if galaxy_themes_use_iframe is defined | default(false) and subdomain %}
```

This ensures that the iframe branch only executes when both:

- `galaxy_themes_use_iframe` is defined and `true`
- `subdomain` is defined in the current task context

and thus avoids the `AnsibleUndefinedVariable: 'subdomain'` is undefined error during basedomain template rendering.


