### PR TITLE
Fix themes_config_file_by_host to always contain a dict

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,7 @@ galaxy_manage_gravity: "{{ false if __galaxy_major_version is version('22.05', '
 galaxy_manage_systemd: no # For Galaxy
 galaxy_manage_systemd_reports: no # For Reports
 galaxy_manage_cleanup: no
-galaxy_manage_themes: "{{ galaxy_manage_static_setup and (galaxy_themes is defined or galaxy_themes_subdomains) }}"
+galaxy_manage_themes: "{{ galaxy_manage_static_setup and (galaxy_themes is defined or galaxy_themes_subdomains | length > 0) }}"
 galaxy_manage_subdomain_static: no
 galaxy_manage_host_filters: no
 galaxy_auto_brand: no # automatically sets the subdomain name as brand
@@ -302,63 +302,15 @@ galaxy_app_config_default:
 
   # Static and themes configuration, will only be added if galaxy_manage_themes
   static_enabled: "{{ galaxy_manage_subdomain_static }}"
-  static_dir_by_host: >
-    { {% if galaxy_manage_subdomain_static %}
-    '{{ galaxy_themes_instance_domain }}': '{{ galaxy_static_dir }}/',
-    {% for subdomain in galaxy_themes_subdomains %}
-    '{{ subdomain.name }}.{{ galaxy_themes_instance_domain}}': '{{ galaxy_themes_static_path }}/static-{{ subdomain.name }}/',
-    {% endfor %}
-    {% endif %} }
-  static_images_dir_by_host: >
-    { {% if galaxy_manage_subdomain_static %}
-    '{{ galaxy_themes_instance_domain }}': '{{ galaxy_static_dir }}/images',
-    {% for subdomain in galaxy_themes_subdomains %}
-    '{{ subdomain.name }}.{{ galaxy_themes_instance_domain}}': '{{ galaxy_themes_static_path }}/static-{{ subdomain.name }}/images',
-    {% endfor %}
-    {% endif %} }
-  static_welcome_html_by_host: >
-    { {% if galaxy_manage_subdomain_static %}
-    '{{ galaxy_themes_instance_domain }}': '{{ galaxy_static_dir }}/welcome.html',
-    {% for subdomain in galaxy_themes_subdomains %}
-    '{{ subdomain.name }}.{{ galaxy_themes_instance_domain}}': '{{ galaxy_themes_static_path }}/static-{{ subdomain.name }}/welcome.html',
-    {% endfor %}
-    {% endif %} }
-  static_scripts_dir_by_host: >
-    { {% if galaxy_manage_subdomain_static %}
-    '{{ galaxy_themes_instance_domain }}': '{{ galaxy_static_dir }}/scripts',
-    {% for subdomain in galaxy_themes_subdomains %}
-    '{{ subdomain.name }}.{{ galaxy_themes_instance_domain}}': '{{ galaxy_themes_static_path }}/static-{{ subdomain.name }}/scripts',
-    {% endfor %}
-    {% endif %} }
-  static_favicon_dir_by_host: >
-    { {% if galaxy_manage_subdomain_static %}
-    '{{ galaxy_themes_instance_domain }}': '{{ galaxy_static_dir }}',
-    {% for subdomain in galaxy_themes_subdomains %}
-    '{{ subdomain.name }}.{{ galaxy_themes_instance_domain}}': '{{ galaxy_themes_static_path }}/static-{{ subdomain.name }}',
-    {% endfor %}
-    {% endif %} }
-  static_robots_txt_by_host: >
-    { {% if galaxy_manage_subdomain_static %}
-    '{{ galaxy_themes_instance_domain }}': '{{ galaxy_static_dir }}',
-    {% for subdomain in galaxy_themes_subdomains %}
-    '{{ subdomain.name }}.{{ galaxy_themes_instance_domain}}': '{{ galaxy_themes_static_path }}/static-{{ subdomain.name }}',
-    {% endfor %}
-    {% endif %} }
-  themes_config_file_by_host: "{{ {} if not (galaxy_manage_themes and galaxy_themes_subdomains) else _themes_config_file_by_host }}"
-  brand_by_host: >
-    { {% if galaxy_auto_brand %}
-    '{{ galaxy_themes_instance_domain }}': '{{ galaxy_themes_instance_domain }}',
-    {% for subdomain in galaxy_themes_subdomains %}
-    '{{ subdomain.name  }}.{{ galaxy_themes_instance_domain}}': '{{ subdomain.name[0]|upper }}{{ subdomain.name[1:] }}',
-    {% endfor %}
-    {% endif %} }
-# Helper variable for themes_config_file_by_host - builds actual dict instead of string
-_themes_config_file_by_host:
-  "{{ galaxy_themes_instance_domain }}": "{{ galaxy_config.galaxy.themes_config_file | default((galaxy_config_dir, 'themes_conf.yml') | path_join) }}"
-{% for subdomain in galaxy_themes_subdomains if subdomain.theme is defined %}
-  "{{ subdomain.name }}.{{ galaxy_themes_instance_domain }}": "themes_conf-{{ subdomain.name }}.yml"
-{% endfor %}
-
+  # The following *_by_host dicts are built at runtime in tasks/config-facts.yml
+  static_dir_by_host: {}
+  static_images_dir_by_host: {}
+  static_welcome_html_by_host: {}
+  static_scripts_dir_by_host: {}
+  static_favicon_dir_by_host: {}
+  static_robots_txt_by_host: {}
+  themes_config_file_by_host: {}
+  brand_by_host: {}
 # Need to set galaxy_config_default[galaxy_app_config_section] dynamically but Ansible/Jinja2 does not make this easy
 galaxy_config_default: "{{ {} | combine({galaxy_app_config_section: galaxy_app_config_default}) }}"
 galaxy_config_merged: "{{ galaxy_config_default | combine(galaxy_config | default({}), recursive=True) }}"

--- a/tasks/config-facts.yml
+++ b/tasks/config-facts.yml
@@ -1,0 +1,210 @@
+---
+# Build proper dict variables for *_by_host configuration to avoid string literals
+# This fixes the bug where these variables would evaluate to malformed strings
+# like '{  }\n\n        ' instead of empty dicts when conditions are false
+
+- name: Build static_dir_by_host dict
+  set_fact:
+    _galaxy_static_dir_by_host_dict: >-
+      {{
+        _galaxy_static_dir_by_host_dict | default({}) |
+        combine({
+          (subdomain.name ~ '.' ~ galaxy_themes_instance_domain): (galaxy_themes_static_path ~ '/static-' ~ subdomain.name ~ '/')
+        })
+      }}
+  loop: "{{ galaxy_themes_subdomains }}"
+  loop_control:
+    loop_var: subdomain
+  when: galaxy_manage_subdomain_static
+
+- name: Add base domain to static_dir_by_host dict
+  set_fact:
+    _galaxy_static_dir_by_host_dict: >-
+      {{
+        _galaxy_static_dir_by_host_dict | default({}) |
+        combine({galaxy_themes_instance_domain: (galaxy_static_dir ~ '/')})
+      }}
+  when: galaxy_manage_subdomain_static
+
+- name: Build static_images_dir_by_host dict
+  set_fact:
+    _galaxy_static_images_dir_by_host_dict: >-
+      {{
+        _galaxy_static_images_dir_by_host_dict | default({}) |
+        combine({
+          (subdomain.name ~ '.' ~ galaxy_themes_instance_domain): (galaxy_themes_static_path ~ '/static-' ~ subdomain.name ~ '/images')
+        })
+      }}
+  loop: "{{ galaxy_themes_subdomains }}"
+  loop_control:
+    loop_var: subdomain
+  when: galaxy_manage_subdomain_static
+
+- name: Add base domain to static_images_dir_by_host dict
+  set_fact:
+    _galaxy_static_images_dir_by_host_dict: >-
+      {{
+        _galaxy_static_images_dir_by_host_dict | default({}) |
+        combine({galaxy_themes_instance_domain: (galaxy_static_dir ~ '/images')})
+      }}
+  when: galaxy_manage_subdomain_static
+
+- name: Build static_welcome_html_by_host dict
+  set_fact:
+    _galaxy_static_welcome_html_by_host_dict: >-
+      {{
+        _galaxy_static_welcome_html_by_host_dict | default({}) |
+        combine({
+          (subdomain.name ~ '.' ~ galaxy_themes_instance_domain): (galaxy_themes_static_path ~ '/static-' ~ subdomain.name ~ '/welcome.html')
+        })
+      }}
+  loop: "{{ galaxy_themes_subdomains }}"
+  loop_control:
+    loop_var: subdomain
+  when: galaxy_manage_subdomain_static
+
+- name: Add base domain to static_welcome_html_by_host dict
+  set_fact:
+    _galaxy_static_welcome_html_by_host_dict: >-
+      {{
+        _galaxy_static_welcome_html_by_host_dict | default({}) |
+        combine({galaxy_themes_instance_domain: (galaxy_static_dir ~ '/welcome.html')})
+      }}
+  when: galaxy_manage_subdomain_static
+
+- name: Build static_scripts_dir_by_host dict
+  set_fact:
+    _galaxy_static_scripts_dir_by_host_dict: >-
+      {{
+        _galaxy_static_scripts_dir_by_host_dict | default({}) |
+        combine({
+          (subdomain.name ~ '.' ~ galaxy_themes_instance_domain): (galaxy_themes_static_path ~ '/static-' ~ subdomain.name ~ '/scripts')
+        })
+      }}
+  loop: "{{ galaxy_themes_subdomains }}"
+  loop_control:
+    loop_var: subdomain
+  when: galaxy_manage_subdomain_static
+
+- name: Add base domain to static_scripts_dir_by_host dict
+  set_fact:
+    _galaxy_static_scripts_dir_by_host_dict: >-
+      {{
+        _galaxy_static_scripts_dir_by_host_dict | default({}) |
+        combine({galaxy_themes_instance_domain: (galaxy_static_dir ~ '/scripts')})
+      }}
+  when: galaxy_manage_subdomain_static
+
+- name: Build static_favicon_dir_by_host dict
+  set_fact:
+    _galaxy_static_favicon_dir_by_host_dict: >-
+      {{
+        _galaxy_static_favicon_dir_by_host_dict | default({}) |
+        combine({
+          (subdomain.name ~ '.' ~ galaxy_themes_instance_domain): (galaxy_themes_static_path ~ '/static-' ~ subdomain.name)
+        })
+      }}
+  loop: "{{ galaxy_themes_subdomains }}"
+  loop_control:
+    loop_var: subdomain
+  when: galaxy_manage_subdomain_static
+
+- name: Add base domain to static_favicon_dir_by_host dict
+  set_fact:
+    _galaxy_static_favicon_dir_by_host_dict: >-
+      {{
+        _galaxy_static_favicon_dir_by_host_dict | default({}) |
+        combine({galaxy_themes_instance_domain: galaxy_static_dir})
+      }}
+  when: galaxy_manage_subdomain_static
+
+- name: Build static_robots_txt_by_host dict
+  set_fact:
+    _galaxy_static_robots_txt_by_host_dict: >-
+      {{
+        _galaxy_static_robots_txt_by_host_dict | default({}) |
+        combine({
+          (subdomain.name ~ '.' ~ galaxy_themes_instance_domain): (galaxy_themes_static_path ~ '/static-' ~ subdomain.name)
+        })
+      }}
+  loop: "{{ galaxy_themes_subdomains }}"
+  loop_control:
+    loop_var: subdomain
+  when: galaxy_manage_subdomain_static
+
+- name: Add base domain to static_robots_txt_by_host dict
+  set_fact:
+    _galaxy_static_robots_txt_by_host_dict: >-
+      {{
+        _galaxy_static_robots_txt_by_host_dict | default({}) |
+        combine({galaxy_themes_instance_domain: galaxy_static_dir})
+      }}
+  when: galaxy_manage_subdomain_static
+
+- name: Build themes_config_file_by_host dict for subdomains
+  set_fact:
+    _galaxy_themes_config_file_by_host_dict: >-
+      {{
+        _galaxy_themes_config_file_by_host_dict | default({}) |
+        combine({
+          (subdomain.name ~ '.' ~ galaxy_themes_instance_domain): ('themes_conf-' ~ subdomain.name ~ '.yml')
+        })
+      }}
+  loop: "{{ galaxy_themes_subdomains }}"
+  loop_control:
+    loop_var: subdomain
+  when:
+    - galaxy_manage_themes
+    - galaxy_themes_subdomains | length > 0
+    - subdomain.theme is defined
+
+- name: Add base domain to themes_config_file_by_host dict
+  set_fact:
+    _galaxy_themes_config_file_by_host_dict: >-
+      {{
+        _galaxy_themes_config_file_by_host_dict | default({}) |
+        combine({galaxy_themes_instance_domain: (galaxy_config.galaxy.themes_config_file | default((galaxy_config_dir, 'themes_conf.yml') | path_join))})
+      }}
+  when:
+    - galaxy_manage_themes
+    - galaxy_themes_subdomains | length > 0
+
+- name: Build brand_by_host dict
+  set_fact:
+    _galaxy_brand_by_host_dict: >-
+      {{
+        _galaxy_brand_by_host_dict | default({}) |
+        combine({
+          (subdomain.name ~ '.' ~ galaxy_themes_instance_domain): (subdomain.name[0]|upper ~ subdomain.name[1:])
+        })
+      }}
+  loop: "{{ galaxy_themes_subdomains }}"
+  loop_control:
+    loop_var: subdomain
+  when: galaxy_auto_brand
+
+- name: Add base domain to brand_by_host dict
+  set_fact:
+    _galaxy_brand_by_host_dict: >-
+      {{
+        _galaxy_brand_by_host_dict | default({}) |
+        combine({galaxy_themes_instance_domain: galaxy_themes_instance_domain})
+      }}
+  when: galaxy_auto_brand
+
+- name: Override galaxy_app_config_default with proper dict values
+  set_fact:
+    galaxy_app_config_default: >-
+      {{
+        galaxy_app_config_default |
+        combine({
+          'static_dir_by_host': _galaxy_static_dir_by_host_dict | default({}),
+          'static_images_dir_by_host': _galaxy_static_images_dir_by_host_dict | default({}),
+          'static_welcome_html_by_host': _galaxy_static_welcome_html_by_host_dict | default({}),
+          'static_scripts_dir_by_host': _galaxy_static_scripts_dir_by_host_dict | default({}),
+          'static_favicon_dir_by_host': _galaxy_static_favicon_dir_by_host_dict | default({}),
+          'static_robots_txt_by_host': _galaxy_static_robots_txt_by_host_dict | default({}),
+          'themes_config_file_by_host': _galaxy_themes_config_file_by_host_dict | default({}),
+          'brand_by_host': _galaxy_brand_by_host_dict | default({})
+        })
+      }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,10 @@
   import_tasks: layout.yml
   tags: always
 
+- name: Build config facts for *_by_host variables
+  import_tasks: config-facts.yml
+  tags: always
+
 - name: Include user creation tasks
   include_tasks:
     file: user.yml


### PR DESCRIPTION
When themes are disabled, either by setting `galaxy_manage_themes: false` or if there are no `galaxy_themes_subdomains`, the use of the YAML folded block scalar operator (`>`) causes the variable `themes_config_file_by_host` to evaluate the string `'{ }'` rather than to an empty dictionary.  This causes Galaxy's config parser to fail when it tries to call `.items()` on a string.

With this PR:
  1. When themes are disabled (galaxy_manage_themes: false or no galaxy_themes_subdomains):
    - Returns an empty dict {}
    - Not a string "{ }"
  2. When themes are enabled (both conditions true):
    - Uses _themes_config_file_by_host which is a proper YAML dictionary
    - Each host is a key with its corresponding theme config file as the value

Closes #231 
