### PR TITLE
Incorporate client-25.1 changes

### DIFF
--- a/tasks/_inc_client_build_make.yml
+++ b/tasks/_inc_client_build_make.yml
@@ -7,6 +7,7 @@
   environment:
     PATH: "{{ galaxy_venv_dir }}/bin:{{ ansible_env.PATH }}"
     VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+    COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
 
 - name: Fetch client version
   slurp:

--- a/tasks/_inc_client_build_steps.yml
+++ b/tasks/_inc_client_build_steps.yml
@@ -2,7 +2,7 @@
 
 - name: Install packages with yarn
   yarn:
-    executable: "yarn --network-timeout 300000 --check-files"
+    executable: "corepack yarn --network-timeout 300000 --check-files"
     path: "{{ galaxy_server_dir }}/client"
   environment:
     PATH: "{{ galaxy_venv_dir }}/bin:{{ ansible_env.PATH }}"
@@ -20,7 +20,7 @@
     fail_msg: "Deconstructed client build is not supported for Galaxy version {{ __galaxy_major_version }}, please set 'galaxy_client_make_target'"
 
 - name: Run gulp  # noqa no-changed-when
-  command: yarn run gulp {{ item }}
+  command: corepack yarn run gulp {{ item }}
   args:
     chdir: "{{ galaxy_server_dir }}/client"
   with_items: "{{ galaxy_client_build_steps[__galaxy_major_version] | default(galaxy_client_build_steps.default) }}"
@@ -30,16 +30,16 @@
     NODE_ENV: "{{ galaxy_client_node_env }}"
 
 - name: Run webpack  # noqa no-changed-when
-  command: "yarn run webpack{{ (galaxy_client_node_env == 'production') | ternary('-production', '') }}"
+  command: "corepack yarn run webpack{{ (galaxy_client_node_env == 'production') | ternary('-production', '') }}"
   args:
     chdir: "{{ galaxy_server_dir }}/client"
   environment:
     PATH: "{{ galaxy_server_dir }}/client/node_modules/.bin:{{ galaxy_venv_dir }}/bin:{{ ansible_env.PATH }}"
     VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
-    NODE_OPTIONS: --max_old_space_size=4096
+    NODE_OPTIONS: --max_old_space_size=8192
 
 - name: Stage built client
-  command: "yarn run stage-build"
+  command: "corepack yarn run stage-build"
   args:
     chdir: "{{ galaxy_server_dir }}/client"
   environment:

--- a/tasks/_inc_client_build_steps.yml
+++ b/tasks/_inc_client_build_steps.yml
@@ -1,16 +1,15 @@
 ---
+- name: Ensure Galaxy version is set
+  include_tasks: _inc_galaxy_version.yml
+  when: __galaxy_major_version is undefined
 
 - name: Install packages with yarn
   yarn:
-    executable: "corepack yarn --network-timeout 300000 --check-files"
+    executable: "{{ __galaxy_major_version is version('25.1', '>=') | ternary('corepack ', '') }}yarn --network-timeout 300000 --check-files"
     path: "{{ galaxy_server_dir }}/client"
   environment:
     PATH: "{{ galaxy_venv_dir }}/bin:{{ ansible_env.PATH }}"
     VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
-
-- name: Ensure Galaxy version is set
-  include_tasks: _inc_galaxy_version.yml
-  when: __galaxy_major_version is undefined
 
 - name: Ensure deconstructed build is supported
   assert:
@@ -20,7 +19,7 @@
     fail_msg: "Deconstructed client build is not supported for Galaxy version {{ __galaxy_major_version }}, please set 'galaxy_client_make_target'"
 
 - name: Run gulp  # noqa no-changed-when
-  command: corepack yarn run gulp {{ item }}
+  command: "{{ __galaxy_major_version is version('25.1', '>=') | ternary('corepack ', '') }}yarn run gulp {{ item }}"
   args:
     chdir: "{{ galaxy_server_dir }}/client"
   with_items: "{{ galaxy_client_build_steps[__galaxy_major_version] | default(galaxy_client_build_steps.default) }}"
@@ -30,7 +29,7 @@
     NODE_ENV: "{{ galaxy_client_node_env }}"
 
 - name: Run webpack  # noqa no-changed-when
-  command: "corepack yarn run webpack{{ (galaxy_client_node_env == 'production') | ternary('-production', '') }}"
+  command: "{{ __galaxy_major_version is version('25.1', '>=') | ternary('corepack ', '') }}yarn run webpack{{ (galaxy_client_node_env == 'production') | ternary('-production', '') }}"
   args:
     chdir: "{{ galaxy_server_dir }}/client"
   environment:
@@ -39,7 +38,7 @@
     NODE_OPTIONS: --max_old_space_size=8192
 
 - name: Stage built client
-  command: "corepack yarn run stage-build"
+  command: "{{ __galaxy_major_version is version('25.1', '>=') | ternary('corepack ', '') }}yarn run stage-build"
   args:
     chdir: "{{ galaxy_server_dir }}/client"
   environment:

--- a/tasks/_inc_client_install_tools.yml
+++ b/tasks/_inc_client_install_tools.yml
@@ -6,29 +6,29 @@
       include_tasks: _inc_node_version.yml
       when: galaxy_node_version is undefined
 
-    - name: Check if node is installed
-      stat:
-        path: "{{ galaxy_venv_dir }}/bin/node"
-      register: __galaxy_node_is_installed
+    #- name: Check if node is installed
+    #  stat:
+    #    path: "{{ galaxy_venv_dir }}/bin/node"
+    #  register: __galaxy_node_is_installed
 
-    - name: Collect installed node version
-      command: "{{ galaxy_venv_dir }}/bin/node --version"
-      when: __galaxy_node_is_installed.stat.exists
-      changed_when: false
-      register: __galaxy_installed_node_version
+    #- name: Collect installed node version
+    #  command: "{{ galaxy_venv_dir }}/bin/node --version"
+    #  when: __galaxy_node_is_installed.stat.exists
+    #  changed_when: false
+    #  register: __galaxy_installed_node_version
 
-    - name: Remove node_modules directory when upgrading node
-      file:
-        path: "{{ galaxy_venv_dir }}/lib/node_modules"
-        state: absent
-      when: (not __galaxy_node_is_installed.stat.exists) or (('v' ~ galaxy_node_version) != __galaxy_installed_node_version.stdout)
+    #- name: Remove node_modules directory when upgrading node
+    #  file:
+    #    path: "{{ galaxy_venv_dir }}/lib/node_modules"
+    #    state: absent
+    #  when: (not __galaxy_node_is_installed.stat.exists) or (('v' ~ galaxy_node_version) != __galaxy_installed_node_version.stdout)
 
-    - name: Install or upgrade node
-      command: "nodeenv -n {{ galaxy_node_version }} -p"
-      environment:
-        PATH: "{{ galaxy_venv_dir }}/bin:{{ ansible_env.PATH }}"
-        VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
-      when: (not __galaxy_node_is_installed.stat.exists) or (('v' ~ galaxy_node_version) != __galaxy_installed_node_version.stdout)
+    #- name: Install or upgrade node
+    #  command: "nodeenv -n {{ galaxy_node_version }} -p"
+    #  environment:
+    #    PATH: "{{ galaxy_venv_dir }}/bin:{{ ansible_env.PATH }}"
+    #    VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+    #  when: (not __galaxy_node_is_installed.stat.exists) or (('v' ~ galaxy_node_version) != __galaxy_installed_node_version.stdout)
 
     - name: Install yarn
       npm:

--- a/tasks/_inc_client_install_tools.yml
+++ b/tasks/_inc_client_install_tools.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Ensure Galaxy version is set
   include_tasks: _inc_galaxy_version.yml
   when: __galaxy_major_version is undefined

--- a/tasks/_inc_client_install_tools.yml
+++ b/tasks/_inc_client_install_tools.yml
@@ -1,34 +1,39 @@
 ---
 
+- name: Ensure Galaxy version is set
+  include_tasks: _inc_galaxy_version.yml
+  when: __galaxy_major_version is undefined
+
 - name: Install client build tools
+  when: __galaxy_major_version is version('25.1', '<')
   block:
     - name: Ensure galaxy_node_version is set
       include_tasks: _inc_node_version.yml
       when: galaxy_node_version is undefined
 
-    #- name: Check if node is installed
-    #  stat:
-    #    path: "{{ galaxy_venv_dir }}/bin/node"
-    #  register: __galaxy_node_is_installed
+    - name: Check if node is installed
+      stat:
+        path: "{{ galaxy_venv_dir }}/bin/node"
+      register: __galaxy_node_is_installed
 
-    #- name: Collect installed node version
-    #  command: "{{ galaxy_venv_dir }}/bin/node --version"
-    #  when: __galaxy_node_is_installed.stat.exists
-    #  changed_when: false
-    #  register: __galaxy_installed_node_version
+    - name: Collect installed node version
+      command: "{{ galaxy_venv_dir }}/bin/node --version"
+      when: __galaxy_node_is_installed.stat.exists
+      changed_when: false
+      register: __galaxy_installed_node_version
 
-    #- name: Remove node_modules directory when upgrading node
-    #  file:
-    #    path: "{{ galaxy_venv_dir }}/lib/node_modules"
-    #    state: absent
-    #  when: (not __galaxy_node_is_installed.stat.exists) or (('v' ~ galaxy_node_version) != __galaxy_installed_node_version.stdout)
+    - name: Remove node_modules directory when upgrading node
+      file:
+        path: "{{ galaxy_venv_dir }}/lib/node_modules"
+        state: absent
+      when: (not __galaxy_node_is_installed.stat.exists) or (('v' ~ galaxy_node_version) != __galaxy_installed_node_version.stdout)
 
-    #- name: Install or upgrade node
-    #  command: "nodeenv -n {{ galaxy_node_version }} -p"
-    #  environment:
-    #    PATH: "{{ galaxy_venv_dir }}/bin:{{ ansible_env.PATH }}"
-    #    VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
-    #  when: (not __galaxy_node_is_installed.stat.exists) or (('v' ~ galaxy_node_version) != __galaxy_installed_node_version.stdout)
+    - name: Install or upgrade node
+      command: "nodeenv -n {{ galaxy_node_version }} -p"
+      environment:
+        PATH: "{{ galaxy_venv_dir }}/bin:{{ ansible_env.PATH }}"
+        VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+      when: (not __galaxy_node_is_installed.stat.exists) or (('v' ~ galaxy_node_version) != __galaxy_installed_node_version.stdout)
 
     - name: Install yarn
       npm:

--- a/tasks/_inc_node_version.yml
+++ b/tasks/_inc_node_version.yml
@@ -33,26 +33,26 @@
 
     # if the client build is being executed independently, nodeenv may not be already installed.
     # If so, setup a virtualenv with nodeenv installed.
-    - name: Check whether nodeenv is available
-      stat:
-        path: "{{ galaxy_venv_dir }}/bin/nodeenv"
-      register: nodeenv_availability
+    #- name: Check whether nodeenv is available
+    #  stat:
+    #    path: "{{ galaxy_venv_dir }}/bin/nodeenv"
+    #  register: nodeenv_availability
 
-    - name: Setup nodeenv if required
-      block:
-        - name: Include virtualenv setup tasks
-          import_tasks: virtualenv.yml
+    #- name: Setup nodeenv if required
+    #  block:
+    #    - name: Include virtualenv setup tasks
+    #      import_tasks: virtualenv.yml
 
-        - name: Install nodeenv if it doesn't exist
-          pip:
-            name: nodeenv
-            virtualenv: "{{ galaxy_venv_dir }}"
-            extra_args: "{{ pip_extra_args | default('') }}"
-            virtualenv_command: "{{ galaxy_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
-            virtualenv_python: "{{ galaxy_virtualenv_python | default(omit) }}"
-          environment:
-            VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
-      when: not nodeenv_availability.stat.exists
+    #    - name: Install nodeenv if it doesn't exist
+    #      pip:
+    #        name: nodeenv
+    #        virtualenv: "{{ galaxy_venv_dir }}"
+    #        extra_args: "{{ pip_extra_args | default('') }}"
+    #        virtualenv_command: "{{ galaxy_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
+    #        virtualenv_python: "{{ galaxy_virtualenv_python | default(omit) }}"
+    #      environment:
+    #        VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+    #  when: not nodeenv_availability.stat.exists
 
   rescue:
 

--- a/tasks/_inc_node_version.yml
+++ b/tasks/_inc_node_version.yml
@@ -33,26 +33,26 @@
 
     # if the client build is being executed independently, nodeenv may not be already installed.
     # If so, setup a virtualenv with nodeenv installed.
-    #- name: Check whether nodeenv is available
-    #  stat:
-    #    path: "{{ galaxy_venv_dir }}/bin/nodeenv"
-    #  register: nodeenv_availability
+    - name: Check whether nodeenv is available
+      stat:
+        path: "{{ galaxy_venv_dir }}/bin/nodeenv"
+      register: nodeenv_availability
 
-    #- name: Setup nodeenv if required
-    #  block:
-    #    - name: Include virtualenv setup tasks
-    #      import_tasks: virtualenv.yml
+    - name: Setup nodeenv if required
+      block:
+        - name: Include virtualenv setup tasks
+          import_tasks: virtualenv.yml
 
-    #    - name: Install nodeenv if it doesn't exist
-    #      pip:
-    #        name: nodeenv
-    #        virtualenv: "{{ galaxy_venv_dir }}"
-    #        extra_args: "{{ pip_extra_args | default('') }}"
-    #        virtualenv_command: "{{ galaxy_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
-    #        virtualenv_python: "{{ galaxy_virtualenv_python | default(omit) }}"
-    #      environment:
-    #        VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
-    #  when: not nodeenv_availability.stat.exists
+        - name: Install nodeenv if it doesn't exist
+          pip:
+            name: nodeenv
+            virtualenv: "{{ galaxy_venv_dir }}"
+            extra_args: "{{ pip_extra_args | default('') }}"
+            virtualenv_command: "{{ galaxy_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
+            virtualenv_python: "{{ galaxy_virtualenv_python | default(omit) }}"
+          environment:
+            VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+      when: not nodeenv_availability.stat.exists
 
   rescue:
 


### PR DESCRIPTION
I’ve cherry picked Nate’s commit from the client-25.1 branch and added some conditionals around ‘galaxy_major_version’. Nothing in  `tasks/_inc_client_install_tools.yml` appears to be necessary for release_25.1. env `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` was necessary for deploying the release on Galaxy Australia this morning.

Resolves #239 