### PR TITLE
Fix bug templating subdomain static dirs via Ansible module

### DIFF
--- a/library/symlink_clone.py
+++ b/library/symlink_clone.py
@@ -148,6 +148,26 @@ def set_permissions(
                 )
 
 
+def compare_dirs(src: Path, dst: Path) -> bool:
+    """Compare two directories recursively."""
+    comparison = filecmp.dircmp(src, dst)
+
+    changed = bool(
+        comparison.left_only
+        # or comparison.right_only  # target may contain extra files
+        or comparison.diff_files
+        or comparison.funny_files
+    )
+    if changed:
+        return True
+
+    for subdir in comparison.common_dirs:
+        if compare_dirs(src / subdir, dst / subdir):
+            return True
+
+    return False
+
+
 def run_module():
     """Run the Ansible module."""
     module = AnsibleModule(
@@ -232,15 +252,9 @@ def run_module():
 
         # determine if anything was changed
         if target.exists():
-            comparison = filecmp.dircmp(temp_path, target)
+            comparison = compare_dirs(temp_path, target)
             permissions = compare_permissions(temp_path, target)
-            changed = bool(
-                comparison.left_only
-                # or comparison.right_only  # target contain have extra files
-                or comparison.diff_files
-                or comparison.funny_files
-                or permissions
-            )
+            changed = comparison or permissions
         else:
             changed = True
     # merge source with target if anything changed

--- a/library/symlink_clone.py
+++ b/library/symlink_clone.py
@@ -149,7 +149,12 @@ def set_permissions(
 
 
 def compare_dirs(src: Path, dst: Path) -> bool:
-    """Compare two directories recursively."""
+    """Compare two directories recursively.
+    
+    Returns:
+        True if the directories are different, False if they are considered
+        identical.
+    """
     comparison = filecmp.dircmp(src, dst)
 
     changed = bool(

--- a/library/symlink_clone.py
+++ b/library/symlink_clone.py
@@ -94,7 +94,7 @@ def compare_permissions(src: Path, dest: Path) -> bool:
             dst_path = dest / src_path.relative_to(src)
 
             if not dst_path.exists():  # `src_path` guaranteed to exist
-                return True
+                continue
 
             if src_path.is_symlink() or dst_path.is_symlink():
                 continue

--- a/library/symlink_clone.py
+++ b/library/symlink_clone.py
@@ -93,13 +93,17 @@ def compare_permissions(src: Path, dest: Path) -> bool:
             src_path = root / name if name != root else root
             dst_path = dest / src_path.relative_to(src)
 
+            if not dst_path.exists():  # `src_path` guaranteed to exist
+                return True
+
             if src_path.is_symlink() or dst_path.is_symlink():
                 continue
 
-            src_stat = src_path.lstat()
-            dst_stat = dst_path.lstat()
             if src_path.is_dir() != dst_path.is_dir():
                 return True
+
+            src_stat = src_path.lstat()
+            dst_stat = dst_path.lstat()
             if src_stat.st_mode != dst_stat.st_mode:
                 return True
             if src_stat.st_uid != dst_stat.st_uid:


### PR DESCRIPTION
This PR fixes two problems.

---

**`FileNotFoundError` when a directory doesn't exist in the target subdomain static dir**

If the target path does not exist, `dst_stat = dst_path.lstat()` leads to an error `FileNotFoundError: [Errno 2] No such file or directory: ...`.

Rearrange the line `dst_stat = dst_path.lstat()` and add a check based on `dst_path.exists()` for the case where `src_path.is_dir() == False` and `dst_path.exists() == False`; for example when the source is a file and the target does not exist.

Given that we are not dealing with file types other than symlinks, directories and regular files, that should be enough.

---

**Directory comparisons are not recursive.**

`filecmp.dircmp()` does not compare directories recursively. To detect if subdomain static dirs contents have changed, use a new function `compare_dirs()` that runs `filecmp.dircmp()` recursively.