### PR TITLE
Split config-facts.yml and run only used fact files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -302,13 +302,14 @@ galaxy_app_config_default:
 
   # Static and themes configuration, will only be added if galaxy_manage_themes
   static_enabled: "{{ galaxy_manage_subdomain_static }}"
-  # The following *_by_host dicts are built at runtime in tasks/config-facts.yml
+  # The following static_*_by_host dicts are built at runtime in tasks/static-facts.yml
   static_dir_by_host: {}
   static_images_dir_by_host: {}
   static_welcome_html_by_host: {}
   static_scripts_dir_by_host: {}
   static_favicon_dir_by_host: {}
   static_robots_txt_by_host: {}
+  # The remaining themes_*_by_host and brand_by_host dicts are built at runtime in tasks/themes-facts.yml
   themes_config_file_by_host: {}
   brand_by_host: {}
 # Need to set galaxy_config_default[galaxy_app_config_section] dynamically but Ansible/Jinja2 does not make this easy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,9 +26,17 @@
   import_tasks: layout.yml
   tags: always
 
-- name: Build config facts for *_by_host variables
-  import_tasks: config-facts.yml
-  tags: always
+- name: Build config facts for static_*_by_host variables
+  import_tasks: static-facts.yml
+  when: galaxy_manage_subdomain_static
+  tags:
+    - galaxy_manage_subdomain_static
+
+- name: Build config facts for themes_*_by_host and brand_by_host variables
+  import_tasks: themes-facts.yml
+  when: galaxy_manage_themes
+  tags:
+    - galaxy_manage_themes
 
 - name: Include user creation tasks
   include_tasks:

--- a/tasks/static-facts.yml
+++ b/tasks/static-facts.yml
@@ -141,57 +141,6 @@
       }}
   when: galaxy_manage_subdomain_static
 
-- name: Build themes_config_file_by_host dict for subdomains
-  set_fact:
-    _galaxy_themes_config_file_by_host_dict: >-
-      {{
-        _galaxy_themes_config_file_by_host_dict | default({}) |
-        combine({
-          (subdomain.name ~ '.' ~ galaxy_themes_instance_domain): ('themes_conf-' ~ subdomain.name ~ '.yml')
-        })
-      }}
-  loop: "{{ galaxy_themes_subdomains }}"
-  loop_control:
-    loop_var: subdomain
-  when:
-    - galaxy_manage_themes
-    - galaxy_themes_subdomains | length > 0
-    - subdomain.theme is defined
-
-- name: Add base domain to themes_config_file_by_host dict
-  set_fact:
-    _galaxy_themes_config_file_by_host_dict: >-
-      {{
-        _galaxy_themes_config_file_by_host_dict | default({}) |
-        combine({galaxy_themes_instance_domain: (galaxy_config.galaxy.themes_config_file | default((galaxy_config_dir, 'themes_conf.yml') | path_join))})
-      }}
-  when:
-    - galaxy_manage_themes
-    - galaxy_themes_subdomains | length > 0
-
-- name: Build brand_by_host dict
-  set_fact:
-    _galaxy_brand_by_host_dict: >-
-      {{
-        _galaxy_brand_by_host_dict | default({}) |
-        combine({
-          (subdomain.name ~ '.' ~ galaxy_themes_instance_domain): (subdomain.name[0]|upper ~ subdomain.name[1:])
-        })
-      }}
-  loop: "{{ galaxy_themes_subdomains }}"
-  loop_control:
-    loop_var: subdomain
-  when: galaxy_auto_brand
-
-- name: Add base domain to brand_by_host dict
-  set_fact:
-    _galaxy_brand_by_host_dict: >-
-      {{
-        _galaxy_brand_by_host_dict | default({}) |
-        combine({galaxy_themes_instance_domain: galaxy_themes_instance_domain})
-      }}
-  when: galaxy_auto_brand
-
 - name: Override galaxy_app_config_default with proper dict values
   set_fact:
     galaxy_app_config_default: >-
@@ -203,8 +152,6 @@
           'static_welcome_html_by_host': _galaxy_static_welcome_html_by_host_dict | default({}),
           'static_scripts_dir_by_host': _galaxy_static_scripts_dir_by_host_dict | default({}),
           'static_favicon_dir_by_host': _galaxy_static_favicon_dir_by_host_dict | default({}),
-          'static_robots_txt_by_host': _galaxy_static_robots_txt_by_host_dict | default({}),
-          'themes_config_file_by_host': _galaxy_themes_config_file_by_host_dict | default({}),
-          'brand_by_host': _galaxy_brand_by_host_dict | default({})
+          'static_robots_txt_by_host': _galaxy_static_robots_txt_by_host_dict | default({})
         })
       }}

--- a/tasks/themes-facts.yml
+++ b/tasks/themes-facts.yml
@@ -1,0 +1,61 @@
+- name: Build themes_config_file_by_host dict for subdomains
+  set_fact:
+    _galaxy_themes_config_file_by_host_dict: >-
+      {{
+        _galaxy_themes_config_file_by_host_dict | default({}) |
+        combine({
+          (subdomain.name ~ '.' ~ galaxy_themes_instance_domain): ('themes_conf-' ~ subdomain.name ~ '.yml')
+        })
+      }}
+  loop: "{{ galaxy_themes_subdomains }}"
+  loop_control:
+    loop_var: subdomain
+  when:
+    - galaxy_manage_themes
+    - galaxy_themes_subdomains | length > 0
+    - subdomain.theme is defined
+
+- name: Add base domain to themes_config_file_by_host dict
+  set_fact:
+    _galaxy_themes_config_file_by_host_dict: >-
+      {{
+        _galaxy_themes_config_file_by_host_dict | default({}) |
+        combine({galaxy_themes_instance_domain: (galaxy_config.galaxy.themes_config_file | default((galaxy_config_dir, 'themes_conf.yml') | path_join))})
+      }}
+  when:
+    - galaxy_manage_themes
+    - galaxy_themes_subdomains | length > 0
+
+- name: Build brand_by_host dict
+  set_fact:
+    _galaxy_brand_by_host_dict: >-
+      {{
+        _galaxy_brand_by_host_dict | default({}) |
+        combine({
+          (subdomain.name ~ '.' ~ galaxy_themes_instance_domain): (subdomain.name[0]|upper ~ subdomain.name[1:])
+        })
+      }}
+  loop: "{{ galaxy_themes_subdomains }}"
+  loop_control:
+    loop_var: subdomain
+  when: galaxy_auto_brand
+
+- name: Add base domain to brand_by_host dict
+  set_fact:
+    _galaxy_brand_by_host_dict: >-
+      {{
+        _galaxy_brand_by_host_dict | default({}) |
+        combine({galaxy_themes_instance_domain: galaxy_themes_instance_domain})
+      }}
+  when: galaxy_auto_brand
+
+- name: Override galaxy_app_config_default with proper dict values
+  set_fact:
+    galaxy_app_config_default: >-
+      {{
+        galaxy_app_config_default |
+        combine({
+          'themes_config_file_by_host': _galaxy_themes_config_file_by_host_dict | default({}),
+          'brand_by_host': _galaxy_brand_by_host_dict | default({})
+        })
+      }}


### PR DESCRIPTION
Split config-facts.yml, previously managing all `*_by_host` variables into two files static-facts.yml and themes-facts.yml, each managing now `static_*_by_host` and `themes_*_by_host`, `brand_by_host` variables respectively. The former file is triggered only when `galaxy_manage_subdomain_static` is enabled, the latter when `galaxy_manage_themes` is enabled.

The motivation for this change is that on [usegalaxy-eu/infrastructure-playbook](https://github.com/usegalaxy-eu/infrastructure-playbook) we have this play.

[**sn09.yml**](https://github.com/usegalaxy-eu/infrastructure-playbook/blob/6fa0547e79a24989ab111b792abd1bae85d42da5/sn09.yml)
```yaml
---
- name: UseGalaxy.eu
  hosts: sn09
  become: true
  become_user: root
  vars:
    - ...
  ...
  vars_files:
    - ...
  collections:
    - ...
  handlers:
    - ...
  pre_tasks:
    - ...
  post_tasks:
    - ...
  roles:
    - ...

    # Setup Galaxy user
    - role: galaxyproject.galaxy
      vars:
        galaxy_create_user: true
        galaxy_manage_clone: false
        galaxy_manage_cleanup: false # we should use this
        galaxy_manage_download: false
        galaxy_manage_existing: true
        galaxy_manage_paths: true
        galaxy_manage_static_setup: false
        galaxy_manage_mutable_setup: false
        galaxy_manage_database: false
        galaxy_manage_subdomain_static: false
        galaxy_fetch_dependencies: false
        galaxy_build_client: false
        galaxy_manage_systemd: false # switch to gravity(?)
        galaxy_manage_gravity: false

    - ...

    # The REAL galaxy role call that will install Galaxy and all of its dependencies.
    - role: galaxyproject.galaxy
      vars:
        galaxy_create_user: true
        galaxy_manage_clone: true
        galaxy_manage_cleanup: false # we should use this
        galaxy_manage_download: false
        galaxy_manage_existing: false
        galaxy_manage_static_setup: true
        galaxy_manage_mutable_setup: true
        galaxy_manage_database: true
        galaxy_manage_subdomain_static: true
        galaxy_manage_host_filters: false # test when themes work
        galaxy_manage_systemd: false # switch to gravity(?)
        galaxy_manage_gravity: false
        galaxy_fetch_dependencies: true
        galaxy_build_client: true
        galaxy_client_make_target: client-production

    - ...
```

And https://github.com/galaxyproject/ansible-galaxy/pull/234 touches `galaxy_app_config_default` even if most parts of the `galaxyproject.galaxy` role are disabled during our fist run. That implies that `static_enabled: "{{ galaxy_manage_subdomain_static }}"` is evaluated to `false` during the first role run and stays like that during the second role run.

The changes from this PR look good in dry-run mode `--diff --check`,

```shell
TASK [galaxyproject.galaxy : Create Galaxy configuration file] **************************************************************************************************************
ok: [sn09.galaxyproject.eu]
```
whereas previously we had:

```shell
TASK [galaxyproject.galaxy : Create Galaxy configuration file] *****************
--- before: /opt/galaxy/config/galaxy.yml
+++ after: /scratch/home/centos/.ansible/tmp/ansible-local-2106208b6m58ag3/tmp8cdkx757/galaxy.yml.j2
@@ -215,7 +215,7 @@
         test.usegalaxy.eu: /opt/galaxy/server/static-test/
         usegalaxy.eu: /opt/galaxy/server/static/
         virology.usegalaxy.eu: /opt/galaxy/server/static-virology/
-    static_enabled: true
+    static_enabled: false
     static_favicon_dir_by_host:
         africa.usegalaxy.eu: /opt/galaxy/server/static-africa
         annotation.usegalaxy.eu: /opt/galaxy/server/static-annotation
```