### PR TITLE
Add a variable to restart handler command so that ‘graceful’ can be overridden

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -418,6 +418,7 @@ __galaxy_gravity_pm: "{{ (galaxy_config_merged.gravity | default({})).process_ma
 __galaxy_gravity_instance_name: "{{ (galaxy_config_merged.gravity | default({})).instance_name | default(none) }}"
 galaxy_gravity_wrapper_path: "/usr/local/bin/galaxyctl{{ __galaxy_gravity_instance_name | ternary('-' ~ __galaxy_gravity_instance_name, '') }}"
 galaxy_gravity_command: "{{ galaxy_venv_dir }}/bin/galaxyctl"
+galaxy_gravity_restart_action: graceful
 
 # Currently `mule` (aka uWSGI) and `gravity` (runs Galaxy 22.01+ under gunicorn) are supported
 galaxy_systemd_mode: "{{ 'mule' if __galaxy_major_version is version('22.05', '<') else 'gravity' }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -418,7 +418,9 @@ __galaxy_gravity_pm: "{{ (galaxy_config_merged.gravity | default({})).process_ma
 __galaxy_gravity_instance_name: "{{ (galaxy_config_merged.gravity | default({})).instance_name | default(none) }}"
 galaxy_gravity_wrapper_path: "/usr/local/bin/galaxyctl{{ __galaxy_gravity_instance_name | ternary('-' ~ __galaxy_gravity_instance_name, '') }}"
 galaxy_gravity_command: "{{ galaxy_venv_dir }}/bin/galaxyctl"
-galaxy_gravity_restart_action: graceful
+# Gravity restart behaviour, one of: restart, graceful
+# Documentation: https://gravity.readthedocs.io/en/stable/basic_usage.html#managing-a-production-galaxy
+galaxy_gravity_restart_action: graceful 
 
 # Currently `mule` (aka uWSGI) and `gravity` (runs Galaxy 22.01+ under gunicorn) are supported
 galaxy_systemd_mode: "{{ 'mule' if __galaxy_major_version is version('22.05', '<') else 'gravity' }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -24,7 +24,7 @@
 
 # Gravity handlers for 22.05
 - name: galaxy gravity restart (22.05)
-  command: "{{ galaxy_gravity_command }} graceful"
+  command: "{{ galaxy_gravity_command }} {{ galaxy_gravity_restart_action }}"
   environment:
     GRAVITY_STATE_DIR: "{{ galaxy_gravity_state_dir }}"
   listen: "restart galaxy"
@@ -50,7 +50,7 @@
   become_user: "{{ (__galaxy_gravity_pm == 'systemd' and galaxy_systemd_root) | ternary('root', __galaxy_user_name) }}"
 
 - name: galaxy gravity restart (23.0+)
-  command: "{{ galaxy_gravity_command }} -c {{ galaxy_config_file }} graceful"
+  command: "{{ galaxy_gravity_command }} -c {{ galaxy_config_file }} {{ galaxy_gravity_restart_action }}"
   listen: "restart galaxy"
   when: "galaxy_systemd_mode == 'gravity' and __galaxy_major_version is version('23.0', '>=')"
   become: yes


### PR DESCRIPTION
The restart galaxy handler command being “galaxyctl graceful” is handy and it’s what we want most of the time, but there are occasions when I want to “restart” instead. For example, when Galaxy is switched off for maintenance, there is no benefit to the graceful restart and I’d like to just ‘galaxyctl restart’ by overriding `galaxy_gravity_restart_action`.