### PR TITLE
Fix Galaxy version file path after upstream reorganization

### DIFF
--- a/tasks/_inc_galaxy_version.yml
+++ b/tasks/_inc_galaxy_version.yml
@@ -14,7 +14,7 @@
   register: __galaxy_version_legacy_stat
   when: not __galaxy_version_init_stat.stat.exists
 
-- name: Collect Galaxy version file (new location)
+- name: Collect Galaxy version file for Galaxy 26.1+
   slurp:
     src: "{{ galaxy_server_dir }}/lib/galaxy/version/__init__.py"
   register: __galaxy_version_file

--- a/tasks/_inc_galaxy_version.yml
+++ b/tasks/_inc_galaxy_version.yml
@@ -3,33 +3,22 @@
 
 # Currently only used by mutable config setup but placed in an include because it'll probably be used by more
 
-- name: Check version file location for Galaxy 26.1+ 
-  stat:
-    path: "{{ galaxy_server_dir }}/lib/galaxy/version/__init__.py"
-  register: __galaxy_version_init_stat
-
-- name: Check for legacy Galaxy version file location
-  stat:
-    path: "{{ galaxy_server_dir }}/lib/galaxy/version.py"
-  register: __galaxy_version_legacy_stat
-  when: not __galaxy_version_init_stat.stat.exists
-
-- name: Collect Galaxy version file for Galaxy 26.1+
+- name: Collect Galaxy version file (Galaxy 26.1+)
   slurp:
     src: "{{ galaxy_server_dir }}/lib/galaxy/version/__init__.py"
   register: __galaxy_version_file
-  when: __galaxy_version_init_stat.stat.exists
+  failed_when: false
 
 - name: Collect Galaxy version file (legacy location)
   slurp:
     src: "{{ galaxy_server_dir }}/lib/galaxy/version.py"
   register: __galaxy_version_file
-  when: not __galaxy_version_init_stat.stat.exists and __galaxy_version_legacy_stat.stat.exists
+  when: __galaxy_version_file is not defined or __galaxy_version_file.failed
 
 - name: Fail if Galaxy version file not found
   fail:
-    msg: "Galaxy version file not found at {{ galaxy_server_dir }}/lib/galaxy/version/__init__.py or {{ galaxy_server_dir }}/lib/galaxy/version.py"
-  when: not __galaxy_version_init_stat.stat.exists and not __galaxy_version_legacy_stat.stat.exists
+    msg: "Galaxy version file not found in expected locations"
+  when: __galaxy_version_file.failed is defined and __galaxy_version_file.failed
 
 - name: Determine Galaxy version
   set_fact:

--- a/tasks/_inc_galaxy_version.yml
+++ b/tasks/_inc_galaxy_version.yml
@@ -3,7 +3,7 @@
 
 # Currently only used by mutable config setup but placed in an include because it'll probably be used by more
 
-- name: Check for new Galaxy version file location
+- name: Check version file location for Galaxy 26.1+ 
   stat:
     path: "{{ galaxy_server_dir }}/lib/galaxy/version/__init__.py"
   register: __galaxy_version_init_stat

--- a/tasks/_inc_galaxy_version.yml
+++ b/tasks/_inc_galaxy_version.yml
@@ -3,10 +3,33 @@
 
 # Currently only used by mutable config setup but placed in an include because it'll probably be used by more
 
-- name: Collect Galaxy version file
+- name: Check for new Galaxy version file location
+  stat:
+    path: "{{ galaxy_server_dir }}/lib/galaxy/version/__init__.py"
+  register: __galaxy_version_init_stat
+
+- name: Check for legacy Galaxy version file location
+  stat:
+    path: "{{ galaxy_server_dir }}/lib/galaxy/version.py"
+  register: __galaxy_version_legacy_stat
+  when: not __galaxy_version_init_stat.stat.exists
+
+- name: Collect Galaxy version file (new location)
+  slurp:
+    src: "{{ galaxy_server_dir }}/lib/galaxy/version/__init__.py"
+  register: __galaxy_version_file
+  when: __galaxy_version_init_stat.stat.exists
+
+- name: Collect Galaxy version file (legacy location)
   slurp:
     src: "{{ galaxy_server_dir }}/lib/galaxy/version.py"
   register: __galaxy_version_file
+  when: not __galaxy_version_init_stat.stat.exists and __galaxy_version_legacy_stat.stat.exists
+
+- name: Fail if Galaxy version file not found
+  fail:
+    msg: "Galaxy version file not found at {{ galaxy_server_dir }}/lib/galaxy/version/__init__.py or {{ galaxy_server_dir }}/lib/galaxy/version.py"
+  when: not __galaxy_version_init_stat.stat.exists and not __galaxy_version_legacy_stat.stat.exists
 
 - name: Determine Galaxy version
   set_fact:


### PR DESCRIPTION
This PR fixes a breaking change introduced when Galaxy reorganized their version module structure. Galaxy moved `lib/galaxy/version.py` to `lib/galaxy/version/__init__.py` in their codebase, which broke the "Collect Galaxy version file" task in this Ansible role.

The fix implements backward compatibility by checking for the new file location first (`lib/galaxy/version/__init__.py`) and falling back to the legacy location (`lib/galaxy/version.py`) if the new one doesn't exist. This ensures the role works seamlessly with both older and newer versions of Galaxy. Proper error handling is also added to provide a clear message if neither file location is found.

This change affects multiple tasks that depend on Galaxy version detection, including mutable setup, static setup, systemd configuration, and client build processes.

Closes #247