### PR TITLE
Revert "Fix Galaxy version file path after upstream reorganization"

### DIFF
--- a/tasks/_inc_galaxy_version.yml
+++ b/tasks/_inc_galaxy_version.yml
@@ -3,22 +3,10 @@
 
 # Currently only used by mutable config setup but placed in an include because it'll probably be used by more
 
-- name: Collect Galaxy version file (Galaxy 26.1+)
-  slurp:
-    src: "{{ galaxy_server_dir }}/lib/galaxy/version/__init__.py"
-  register: __galaxy_version_file
-  failed_when: false
-
-- name: Collect Galaxy version file (legacy location)
+- name: Collect Galaxy version file
   slurp:
     src: "{{ galaxy_server_dir }}/lib/galaxy/version.py"
   register: __galaxy_version_file
-  when: __galaxy_version_file is not defined or __galaxy_version_file.failed
-
-- name: Fail if Galaxy version file not found
-  fail:
-    msg: "Galaxy version file not found in expected locations"
-  when: __galaxy_version_file.failed is defined and __galaxy_version_file.failed
 
 - name: Determine Galaxy version
   set_fact:


### PR DESCRIPTION
PR https://github.com/galaxyproject/ansible-galaxy/pull/248 is broken.

Look at this snippet, we run Galaxy 26.0,

```yaml
---
- name: UseGalaxy.eu
  hosts: sn09
  become: true
  become_user: root
  vars_files:
    - group_vars/sn09/sn09.yml
    - group_vars/sn09/themes_conf.yml
    - group_vars/sn09/subdomains.yml
    - group_vars/sn09/toolmsg.yml
    - group_vars/tiaas.yml # All of the training infrastructure
    - group_vars/gxconfig.yml # The base galaxy configuration
    - group_vars/toolbox.yml # User controlled toolbox
    - secret_group_vars/sentry.yml # Sentry SDK init url
    - secret_group_vars/aws.yml # AWS creds
    - secret_group_vars/pulsar.yml # Pulsar + MQ Connections
    - secret_group_vars/oidc.yml # OIDC credentials (ELIXIR, keycloak)
    - secret_group_vars/object_store.yml # Object Store credentils (S3 etc ...)
    - secret_group_vars/db-main.yml # DB URL + some postgres stuff
    - secret_group_vars/file_sources.yml # file_sources_conf.yml creds
    - secret_group_vars/all.yml # All of the other assorted secrets...
    - secret_group_vars/keys.yml # SSH keys
    - templates/galaxy/config/job_conf.yml
    - mounts/dest/all.yml
    - mounts/mountpoints.yml
  tasks:
    - name: Collect Galaxy version file (Galaxy 26.1+)
      slurp:
        src: "{{ galaxy_server_dir }}/lib/galaxy/version/__init__.py"
      register: __galaxy_version_file
      failed_when: false

    - name: Debug
      ansible.builtin.debug:
        var: __galaxy_version_file

    - name: Collect Galaxy version file (legacy location)
      slurp:
        src: "{{ galaxy_server_dir }}/lib/galaxy/version.py"
      register: __galaxy_version_file
      when: __galaxy_version_file is not defined or __galaxy_version_file.failed

    - name: Fail if Galaxy version file not found
      fail:
        msg: "Galaxy version file not found in expected locations"
      when: __galaxy_version_file.failed is defined and __galaxy_version_file.failed

    - name: Determine Galaxy version
      set_fact:
        __galaxy_major_version: >-
            {{
                (__galaxy_version_file['content'] | b64decode).splitlines()
                    | select('match', 'VERSION_MAJOR\s*=.*') | first
                    | regex_replace('^[^\d]+([.\d]+).*', '\1')
            }}
```

then look at the result.

```yaml
$ ansible-playbook sn09.yml --ask-vault-password
Vault password: 
[WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see
details

PLAY [UseGalaxy.eu] *****************************************************************************

TASK [Gathering Facts] **************************************************************************
ok: [sn09.galaxyproject.eu]

TASK [Collect Galaxy version file (Galaxy 26.1+)] ***********************************************
ok: [sn09.galaxyproject.eu]

TASK [Debug] ************************************************************************************
ok: [sn09.galaxyproject.eu] => {
    "__galaxy_version_file": {
        "changed": false,
        "failed": false,
        "failed_when_result": false,
        "msg": "file not found: /opt/galaxy/server/lib/galaxy/version/__init__.py"
    }
}

TASK [Collect Galaxy version file (legacy location)] ********************************************
skipping: [sn09.galaxyproject.eu]

TASK [Fail if Galaxy version file not found] ****************************************************
skipping: [sn09.galaxyproject.eu]

TASK [Determine Galaxy version] *****************************************************************
fatal: [sn09.galaxyproject.eu]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'content'. 'dict object' has no attribute 'content'\n\nThe error appears to be in '/home/jose/Dokumente/Repositories/infrastructure-playbook/sn09.yml': line 48, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Determine Galaxy version\n      ^ here\n"}                                                                                        

PLAY RECAP **************************************************************************************
sn09.galaxyproject.eu      : ok=3    changed=0    unreachable=0    failed=1    skipped=2    rescued=0    ignored=0   
```

It happens because of the `failed_when: false`.