### PR TITLE
Use ignore_errors rather that failed_when

### DIFF
--- a/tasks/_inc_galaxy_version.yml
+++ b/tasks/_inc_galaxy_version.yml
@@ -7,18 +7,13 @@
   slurp:
     src: "{{ galaxy_server_dir }}/lib/galaxy/version/__init__.py"
   register: __galaxy_version_file
-  failed_when: false
+  ignore_errors: true
 
 - name: Collect Galaxy version file (legacy location)
   slurp:
     src: "{{ galaxy_server_dir }}/lib/galaxy/version.py"
   register: __galaxy_version_file
-  when: __galaxy_version_file is not defined or __galaxy_version_file.failed
-
-- name: Fail if Galaxy version file not found
-  fail:
-    msg: "Galaxy version file not found in expected locations"
-  when: __galaxy_version_file.failed is defined and __galaxy_version_file.failed
+  when: __galaxy_version_file.failed
 
 - name: Determine Galaxy version
   set_fact:


### PR DESCRIPTION
A corrected fix for the breaking change introduced when Galaxy reorganized their version module structure.

The previous fix (PR #248) was broken because it used `failed_when: false`, which caused the slurp task to "succeed" even when the file didn't exist, but without populating the `content` field. This led to failures in the subsequent "Determine Galaxy version" task.

This corrected implementation uses `ignore_errors: true` instead, which allows the task to fail naturally when the file doesn't exist, but continues playbook execution. This ensures that when a file is successfully read, the `content` field is properly populated, and when it fails, the `failed` field is correctly set to `true`.

The fix tries the new file location first (`lib/galaxy/version/__init__.py`) and falls back to the legacy location (`lib/galaxy/version.py`) if the first attempt fails. This ensures backward compatibility with both older and newer versions of Galaxy.

Closes #247