### PR TITLE
Fix Galaxy version file path after upstream reorganization - v3

### DIFF
--- a/tasks/_inc_galaxy_version.yml
+++ b/tasks/_inc_galaxy_version.yml
@@ -6,19 +6,19 @@
 - name: Collect Galaxy version file (Galaxy 26.1+)
   slurp:
     src: "{{ galaxy_server_dir }}/lib/galaxy/version/__init__.py"
-  register: __galaxy_version_file_new
+  register: __galaxy_version_file
   ignore_errors: true
 
 - name: Collect Galaxy version file (legacy location)
   slurp:
     src: "{{ galaxy_server_dir }}/lib/galaxy/version.py"
   register: __galaxy_version_file_legacy
-  when: __galaxy_version_file_new.failed
+  when: __galaxy_version_file.failed
   ignore_errors: true
 
 - name: Set final version file variable
   set_fact:
-    __galaxy_version_file: "{{ __galaxy_version_file_new if not __galaxy_version_file_new.failed else __galaxy_version_file_legacy }}"
+    __galaxy_version_file: "{{ __galaxy_version_file if not __galaxy_version_file.failed else __galaxy_version_file_legacy }}"
 
 - name: Determine Galaxy version
   set_fact:

--- a/tasks/_inc_galaxy_version.yml
+++ b/tasks/_inc_galaxy_version.yml
@@ -6,14 +6,19 @@
 - name: Collect Galaxy version file (Galaxy 26.1+)
   slurp:
     src: "{{ galaxy_server_dir }}/lib/galaxy/version/__init__.py"
-  register: __galaxy_version_file
+  register: __galaxy_version_file_new
   ignore_errors: true
 
 - name: Collect Galaxy version file (legacy location)
   slurp:
     src: "{{ galaxy_server_dir }}/lib/galaxy/version.py"
-  register: __galaxy_version_file
-  when: __galaxy_version_file.failed
+  register: __galaxy_version_file_legacy
+  when: __galaxy_version_file_new.failed
+  ignore_errors: true
+
+- name: Set final version file variable
+  set_fact:
+    __galaxy_version_file: "{{ __galaxy_version_file_new if not __galaxy_version_file_new.failed else __galaxy_version_file_legacy }}"
 
 - name: Determine Galaxy version
   set_fact:


### PR DESCRIPTION
Third time's a charm?

This PR provides the correct fix for the breaking change introduced when Galaxy reorganized their version module structure. Galaxy moved `lib/galaxy/version.py` to `lib/galaxy/version/__init__.py` in their codebase, which broke the "Collect Galaxy version file" task in this Ansible role.

## Root Cause Analysis

The previous fixes (PR #248 and PR #250) had critical issues:

1. **PR #248**: Used `failed_when: false`, which caused the slurp task to "succeed" even when the file didn't exist, but without populating the `content` field.

2. **PR #250**: Used `ignore_errors: true` correctly, but had a subtle **variable overwriting bug**. When the fallback task was skipped, Ansible overwrote the successful result variable with the skip result:

```yaml
# Before skip: __galaxy_version_file contains successful file content
# After skip: __galaxy_version_file = {"skipped": true, "skip_reason": "..."}
```

This caused the "Determine Galaxy version" task to fail with `'dict object' has no attribute 'content'`.

This implementation uses separate variable names to prevent the overwriting issue:

## Verification

This fix has been tested with:
- **Galaxy 26.1+ (new structure)**: Successfully reads `lib/galaxy/version/__init__.py` and extracts version
- **Galaxy 25.1 (legacy structure)**: Successfully falls back to `lib/galaxy/version.py` and extracts version

This resolves the Docker build failures seen in Galaxy's CI pipeline while maintaining backward compatibility.

Closes #247