### PR TITLE
Avoid self-referencing set_fact for __galaxy_version_file

### DIFF
--- a/tasks/_inc_galaxy_version.yml
+++ b/tasks/_inc_galaxy_version.yml
@@ -6,19 +6,19 @@
 - name: Collect Galaxy version file (Galaxy 26.1+)
   slurp:
     src: "{{ galaxy_server_dir }}/lib/galaxy/version/__init__.py"
-  register: __galaxy_version_file
+  register: __galaxy_version_file_new
   ignore_errors: true
 
 - name: Collect Galaxy version file (legacy location)
   slurp:
     src: "{{ galaxy_server_dir }}/lib/galaxy/version.py"
   register: __galaxy_version_file_legacy
-  when: __galaxy_version_file.failed
+  when: __galaxy_version_file_new.failed
   ignore_errors: true
 
 - name: Set final version file variable
   set_fact:
-    __galaxy_version_file: "{{ __galaxy_version_file if not __galaxy_version_file.failed else __galaxy_version_file_legacy }}"
+    __galaxy_version_file: "{{ __galaxy_version_file_new if not __galaxy_version_file_new.failed else __galaxy_version_file_legacy }}"
 
 - name: Determine Galaxy version
   set_fact:


### PR DESCRIPTION
## Summary
- Renames the first slurp's register back to `__galaxy_version_file_new` so the merge `set_fact` is not self-referencing.
- Fixes a regression introduced by 27521db ("Improve variable names").

## Why
Ansible 2.19's lazy templating breaks self-referencing `set_fact` of the form `X: "{{ X if not X.failed else Y }}"`. The `X` on the right-hand side resolves against the *new* (still-unevaluated) fact rather than the previous slurp result, so `__galaxy_version_file` ends up pointing at the skipped legacy slurp result. Downstream tasks then fail with:

```
Error while resolving value for '__galaxy_major_version': object of type 'dict' has no attribute 'content'
```

Reported against `_inc_galaxy_version.yml:20` (the `__galaxy_major_version` set_fact) on a Galaxy 26.1+ deployment.

## Test plan
- [ ] Run a Galaxy 26.1+ deployment with Ansible 2.19+ that previously hit the error and confirm `Determine Galaxy version` succeeds.
- [ ] Run against an older deployment that uses the legacy `lib/galaxy/version.py` location and confirm fallback still works.