### PR TITLE
Mark local_tool_conf.xml as not a shed tool conf

### DIFF
--- a/templates/local_tool_conf.xml.j2
+++ b/templates/local_tool_conf.xml.j2
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<toolbox monitor="true" tool_path="{{ galaxy_local_tools_dir }}">
+<toolbox monitor="true" tool_path="{{ galaxy_local_tools_dir }}" is_shed_conf="false">
 {% for tool in galaxy_local_tools %}
 {% if tool is not mapping %}
 {% set tool = {'section_name': 'Local Tools', 'file': tool} %}


### PR DESCRIPTION
While debugging why usegalaxy.ca's admin "Install tool" modal offered an extra, unlabeled "Tool Configuration" destination alongside the real shed tool conf, I traced it to Galaxy core: any `tool_path`-bearing `<toolbox>` without `is_shed_conf="false"` is treated as a valid shed-install target, and `local_tool_conf.xml` (generated by this role's `galaxy_local_tools` feature) didn't set that attribute.

This isn't just a cosmetic UI issue — `local_tool_conf.xml` is fully re-templated from `galaxy_local_tools` on every playbook run, with no awareness of Galaxy's shed-managed `<tool guid="...">` elements. If an admin installed a toolshed repo into it via that UI option, _**the entry would be silently wiped on the next playbook run**_ (this has been verified).

**Additionally confirmed on usegalaxy.ca:** the damage isn't limited to losing the installed tool's entry on the next playbook run — it happens immediately, and it's worse than a content problem. Galaxy persists shed-installed tool confs via a temp-file-write-then-`rename()` pattern (`RenamedTemporaryFile`), which replaces the target file's permissions *and ownership* with those of the process performing the write, rather than preserving the original file's mode/owner. On this instance, `local_tool_conf.xml` was owned by `pgalaxy` (the privileged account this playbook uses to manage config) before the install, and by `galaxy` (the runtime service account) immediately after — meaning a single admin-UI install crossed the instance's privilege-separation boundary on a config file that's supposed to be exclusively privileged-managed. It self-heals on the next playbook run, but the window in between is a real regression, not just a cosmetic one.

Fix: add `is_shed_conf="false"` to the toolbox root so Galaxy excludes it from dynamic/shed tool conf discovery. Not made configurable — there's no safe use case for the opposite behavior given how this file is managed.