### PR TITLE
Stop auto-provisioning migrated_tools_conf.xml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -330,8 +330,6 @@ galaxy_mutable_config_files:
     dest: "{{ galaxy_config_merged[galaxy_app_config_section].shed_tool_data_table_config }}"
 galaxy_mutable_config_templates:
   - src: "shed_tool_conf.xml.j2"
-    dest: "{{ galaxy_config_merged[galaxy_app_config_section].migrated_tools_config }}"
-  - src: "shed_tool_conf.xml.j2"
     dest: "{{ galaxy_shed_tool_config_file }}"
 
 galaxy_config_error_email_to: "{{ galaxy_config_merged[galaxy_app_config_section].error_email_to | default('') }}"


### PR DESCRIPTION
Found while investigating why usegalaxy.ca's admin "Install tool" modal showed a spurious "Tool Configuration" install destination: `migrated_tools_conf.xml` was assumed to be a leftover from old, since-removed tool-migration scripts, so it was deleted manually as a fix. The very next playbook run recreated it — because this role's `galaxy_mutable_config_templates` (`defaults/main.yml`) unconditionally seeds it from the same `shed_tool_conf.xml.j2` template used for the real shed tool conf, whenever it's missing (`mutable_setup.yml`'s `force: no` template task, gated on `galaxy_manage_mutable_setup`, which defaults to `yes`).

So it isn't a historical fossil — every fresh deployment of this role gets an empty, shed-installable `migrated_tools_conf.xml` by design, regardless of whether the deprecated option is ever actually needed.

Fix: drop the `migrated_tools_config` entry from `galaxy_mutable_config_templates`. `force: no` means this task was already a no-op on any host with a genuine populated file, so instances that actually rely on a real `migrated_tools_conf.xml` from historical migrations are unaffected — this only stops the auto-creation of a useless empty one where the file doesn't exist.